### PR TITLE
[ci] Remove unnecessary installation of nfs-common

### DIFF
--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -42,7 +42,6 @@ from: {{ $.BASE_ALT_DEV }}
 
 shell:
   install:
-    - apt update && apt install nfs-common
     - /binary_replace.sh -i "{{ $csiBinaries }}" -o /relocate
 
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR removes the unnecessary installation of the `nfs-common` package in the CI pipeline that was mistakenly added in a previous PR.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `nfs-common` package is already included in the base image used for our CI builds.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
