### PR TITLE
[controller] Fix StorageClass validation webhook and update RBAC for controller

### DIFF
--- a/images/controller/Dockerfile
+++ b/images/controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_SCRATCH=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
-ARG BASE_GOLANG_21_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.21.4-alpine3.18@sha256:cf84f3d6882c49ea04b6478ac514a2582c8922d7e5848b43d2918fff8329f6e6
+ARG BASE_GOLANG_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.22.3-alpine@sha256:dbf216b880b802c22e3f4f2ef0a78396b4a9a6983cb9b767c5efc351ebf946b0
 
-FROM $BASE_GOLANG_21_ALPINE_BUILDER as builder
+FROM $BASE_GOLANG_ALPINE_BUILDER as builder
 
 WORKDIR /go/src
 ADD go.mod .

--- a/images/controller/api/v1alpha1/nfs_storage_class.go
+++ b/images/controller/api/v1alpha1/nfs_storage_class.go
@@ -25,7 +25,6 @@ type NFSStorageClass struct {
 	Status            *NFSStorageClassStatus `json:"status,omitempty"`
 }
 
-// NFSStorageClassList contains a list of empty block device
 type NFSStorageClassList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/images/controller/go.mod
+++ b/images/controller/go.mod
@@ -1,6 +1,6 @@
 module d8-controller
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/images/controller/pkg/controller/controller_suite_test.go
+++ b/images/controller/pkg/controller/controller_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Flant JSC
+Copyright 2024 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -53,6 +53,9 @@ const (
 	NFSStorageClassManagedLabelKey         = "storage.deckhouse.io/managed-by"
 	NFSStorageClassManagedLabelValue       = "nfs-storage-class-controller"
 
+	StorageClassDefaultAnnotationKey     = "storageclass.kubernetes.io/is-default-class"
+	StorageClassDefaultAnnotationValTrue = "true"
+
 	AllowVolumeExpansionDefaultValue = true
 
 	FailedStatusPhase  = "Failed"

--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -49,9 +49,9 @@ const (
 
 	NFSStorageClassProvisioner = "nfs.csi.k8s.io"
 
-	NFSStorageClassFinalizerName     = "storage.deckhouse.io/nfs-storage-class-controller"
-	NFSStorageClassManagedLabelKey   = "storage.deckhouse.io/managed-by"
-	NFSStorageClassManagedLabelValue = "nfs-storage-class-controller"
+	NFSStorageClassControllerFinalizerName = "storage.deckhouse.io/nfs-storage-class-controller"
+	NFSStorageClassManagedLabelKey         = "storage.deckhouse.io/managed-by"
+	NFSStorageClassManagedLabelValue       = "nfs-storage-class-controller"
 
 	AllowVolumeExpansionDefaultValue = true
 
@@ -164,12 +164,12 @@ func RunNFSStorageClassWatcherController(
 }
 
 func RunEventReconcile(ctx context.Context, cl client.Client, log logger.Logger, scList *v1.StorageClassList, nsc *v1alpha1.NFSStorageClass, controllerNamespace string) (shouldRequeue bool, err error) {
-	added, err := addFinalizerIfNotExistsForNSC(ctx, cl, nsc)
+	added, err := addFinalizerIfNotExists(ctx, cl, nsc, NFSStorageClassControllerFinalizerName)
 	if err != nil {
-		err = fmt.Errorf("[reconcileStorageClassCreateFunc] unable to add a finalizer %s to the NFSStorageClass %s: %w", NFSStorageClassFinalizerName, nsc.Name, err)
+		err = fmt.Errorf("[reconcileStorageClassCreateFunc] unable to add a finalizer %s to the NFSStorageClass %s: %w", NFSStorageClassControllerFinalizerName, nsc.Name, err)
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileStorageClassCreateFunc] finalizer %s was added to the NFSStorageClass %s: %t", NFSStorageClassFinalizerName, nsc.Name, added))
+	log.Debug(fmt.Sprintf("[reconcileStorageClassCreateFunc] finalizer %s was added to the NFSStorageClass %s: %t", NFSStorageClassControllerFinalizerName, nsc.Name, added))
 
 	reconcileTypeForStorageClass, err := IdentifyReconcileFuncForStorageClass(log, scList, nsc, controllerNamespace)
 	if err != nil {

--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -132,26 +132,26 @@ func RunNFSStorageClassWatcherController(
 		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 			log.Info(fmt.Sprintf("[UpdateFunc] get event for NFSStorageClass %q. Check if it should be reconciled", e.ObjectNew.GetName()))
 
-			oldLsc, ok := e.ObjectOld.(*v1alpha1.NFSStorageClass)
+			oldNSC, ok := e.ObjectOld.(*v1alpha1.NFSStorageClass)
 			if !ok {
 				err = errors.New("unable to cast event object to a given type")
 				log.Error(err, "[UpdateFunc] an error occurred while handling create event")
 				return
 			}
-			newLsc, ok := e.ObjectNew.(*v1alpha1.NFSStorageClass)
+			newNSC, ok := e.ObjectNew.(*v1alpha1.NFSStorageClass)
 			if !ok {
 				err = errors.New("unable to cast event object to a given type")
 				log.Error(err, "[UpdateFunc] an error occurred while handling create event")
 				return
 			}
 
-			if reflect.DeepEqual(oldLsc.Spec, newLsc.Spec) && newLsc.DeletionTimestamp == nil {
-				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the NFSStorageClass %s has no Spec field updates. It will not be reconciled", newLsc.Name))
+			if reflect.DeepEqual(oldNSC.Spec, newNSC.Spec) && newNSC.DeletionTimestamp == nil {
+				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the NFSStorageClass %s has no Spec field updates. It will not be reconciled", newNSC.Name))
 				return
 			}
 
-			log.Info(fmt.Sprintf("[UpdateFunc] the NFSStorageClass %q will be reconciled. Add to the queue", newLsc.Name))
-			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: newLsc.Namespace, Name: newLsc.Name}}
+			log.Info(fmt.Sprintf("[UpdateFunc] the NFSStorageClass %q will be reconciled. Add to the queue", newNSC.Name))
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: newNSC.Namespace, Name: newNSC.Name}}
 			q.Add(request)
 		},
 	})

--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -73,6 +73,10 @@ const (
 	StorageClassSecretNSKey     = "csi.storage.k8s.io/provisioner-secret-namespace"
 )
 
+var (
+	allowedProvisioners = []string{NFSStorageClassProvisioner}
+)
+
 func RunNFSStorageClassWatcherController(
 	mgr manager.Manager,
 	cfg config.Options,

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -176,12 +176,10 @@ func reconcileStorageClassDeleteFunc(
 
 	if sc != nil {
 		log.Info(fmt.Sprintf("[reconcileStorageClassDeleteFunc] successfully found a storage class for the NFSStorageClass %s", nsc.Name))
-		log.Debug(fmt.Sprintf("[reconcileStorageClassDeleteFunc] starts identifing a provisioner for the storage class %s", sc.Name))
+		log.Debug(fmt.Sprintf("[reconcileStorageClassDeleteFunc] starts identifying a provisioner for the storage class %s", sc.Name))
 
-		if sc.Provisioner != NFSStorageClassProvisioner {
-			log.Info(fmt.Sprintf("[reconcileStorageClassDeleteFunc] the storage class %s does not belongs to %s provisioner. It will not be deleted", sc.Name, NFSStorageClassProvisioner))
-		} else {
-			log.Info(fmt.Sprintf("[reconcileStorageClassDeleteFunc] the storage class %s belongs to %s provisioner. It will be deleted", sc.Name, NFSStorageClassProvisioner))
+		if slices.Contains(allowedProvisioners, sc.Provisioner) {
+			log.Info(fmt.Sprintf("[reconcileStorageClassDeleteFunc] the storage class %s provisioner %s belongs to allowed provisioners: %v", sc.Name, sc.Provisioner, allowedProvisioners))
 
 			err := deleteStorageClass(ctx, cl, sc)
 			if err != nil {
@@ -194,6 +192,10 @@ func reconcileStorageClassDeleteFunc(
 				return true, err
 			}
 			log.Info(fmt.Sprintf("[reconcileStorageClassDeleteFunc] successfully deleted a storage class, name: %s", sc.Name))
+		}
+
+		if !slices.Contains(allowedProvisioners, sc.Provisioner) {
+			log.Info(fmt.Sprintf("[reconcileStorageClassDeleteFunc] the storage class %s provisioner %s does not belong to allowed provisioners: %v", sc.Name, sc.Provisioner, allowedProvisioners))
 		}
 	}
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -568,7 +568,7 @@ func recreateStorageClass(ctx context.Context, cl client.Client, oldSC, newSC *v
 }
 
 func deleteStorageClass(ctx context.Context, cl client.Client, sc *v1.StorageClass) error {
-	if sc.Provisioner != NFSStorageClassProvisioner {
+	if !slices.Contains(allowedProvisioners, sc.Provisioner) {
 		return fmt.Errorf("a storage class %s does not belong to %s provisioner", sc.Name, NFSStorageClassProvisioner)
 	}
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -569,7 +569,7 @@ func recreateStorageClass(ctx context.Context, cl client.Client, oldSC, newSC *v
 
 func deleteStorageClass(ctx context.Context, cl client.Client, sc *v1.StorageClass) error {
 	if !slices.Contains(allowedProvisioners, sc.Provisioner) {
-		return fmt.Errorf("a storage class %s does not belong to %s provisioner", sc.Name, NFSStorageClassProvisioner)
+		return fmt.Errorf("a storage class %s with provisioner %s does not belong to allowed provisioners: %v", sc.Name, sc.Provisioner, allowedProvisioners)
 	}
 
 	_, err := removeFinalizerIfExists(ctx, cl, sc, NFSStorageClassControllerFinalizerName)

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -72,7 +72,7 @@ func ReconcileStorageClassCreateFunc(
 	if created {
 		log.Info(fmt.Sprintf("[reconcileStorageClassCreateFunc] successfully create storage class, name: %s", newSC.Name))
 	} else {
-		log.Warning(fmt.Sprintf("[reconcileLSCCreateFunc] Storage class %s already exists. Adding event to requeue.", newSC.Name))
+		log.Warning(fmt.Sprintf("[reconcileStorageClassCreateFunc] Storage class %s already exists. Adding event to requeue.", newSC.Name))
 		return true, nil
 	}
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -399,8 +399,8 @@ func shouldReconcileStorageClassByUpdateFunc(log logger.Logger, scList *v1.Stora
 	return false, err
 }
 
-func shouldReconcileByDeleteFunc(nsc *v1alpha1.NFSStorageClass) bool {
-	if nsc.DeletionTimestamp != nil {
+func shouldReconcileByDeleteFunc(obj metav1.Object) bool {
+	if obj.GetDeletionTimestamp() != nil {
 		return true
 	}
 
@@ -697,6 +697,7 @@ func shouldReconcileSecretByUpdateFunc(log logger.Logger, secretList *corev1.Sec
 		}
 	}
 
+	log.Debug(fmt.Sprintf("[shouldReconcileSecretByUpdateFunc] a secret %s not found in the list: %+v. It should be created", SecretForMountOptionsPrefix+nsc.Name, secretList.Items))
 	return true, nil
 }
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -26,11 +26,12 @@ import (
 	"strconv"
 	"strings"
 
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -363,7 +364,7 @@ func shouldReconcileStorageClassByUpdateFunc(log logger.Logger, scList *v1.Stora
 
 	for _, oldSC := range scList.Items {
 		if oldSC.Name == nsc.Name {
-			if oldSC.Provisioner == NFSStorageClassProvisioner {
+			if slices.Contains(allowedProvisioners, oldSC.Provisioner) {
 				newSC, err := ConfigureStorageClass(nsc, controllerNamespace)
 				if err != nil {
 					return false, err
@@ -386,7 +387,7 @@ func shouldReconcileStorageClassByUpdateFunc(log logger.Logger, scList *v1.Stora
 				return false, nil
 
 			} else {
-				err := fmt.Errorf("a storage class %s does not belong to %s provisioner", oldSC.Name, NFSStorageClassProvisioner)
+				err := fmt.Errorf("a storage class %s with provisioner % s does not belong to allowed provisioners: %v", oldSC.Name, oldSC.Provisioner, allowedProvisioners)
 				return false, err
 			}
 		}

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -485,6 +485,7 @@ func addFinalizerIfNotExists(ctx context.Context, cl client.Client, obj metav1.O
 	}
 
 	if added {
+		obj.SetFinalizers(finalizers)
 		err := cl.Update(ctx, obj.(client.Object))
 		if err != nil {
 			return false, err

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Flant JSC
+Copyright 2024 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
@@ -355,6 +355,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nsc.Finalizers).To(HaveLen(1))
 		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
+		Expect(nsc.DeletionTimestamp).NotTo(BeNil())
 
 		scList := &v1.StorageClassList{}
 		err = cl.List(ctx, scList)

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
@@ -97,7 +97,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, nsc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		sc := &v1.StorageClass{}
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
@@ -133,7 +133,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		Expect(nsc).NotTo(BeNil())
 		Expect(nsc.Name).To(Equal(nameForTestResource))
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		scList := &v1.StorageClassList{}
 		err = cl.List(ctx, scList)
@@ -146,7 +146,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, nsc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		sc := &v1.StorageClass{}
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
@@ -181,7 +181,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		Expect(nsc).NotTo(BeNil())
 		Expect(nsc.Name).To(Equal(nameForTestResource))
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		scList := &v1.StorageClassList{}
 		err = cl.List(ctx, scList)
@@ -194,7 +194,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, nsc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		sc := &v1.StorageClass{}
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
@@ -232,7 +232,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		Expect(nsc).NotTo(BeNil())
 		Expect(nsc.Name).To(Equal(nameForTestResource))
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		scList := &v1.StorageClassList{}
 		err = cl.List(ctx, scList)
@@ -245,7 +245,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, nsc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		sc := &v1.StorageClass{}
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
@@ -354,7 +354,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		err = cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, nsc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nsc.Finalizers).To(HaveLen(1))
-		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+		Expect(nsc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 
 		scList := &v1.StorageClassList{}
 		err = cl.List(ctx, scList)
@@ -425,7 +425,7 @@ func performStandartChecksForSc(sc *v1.StorageClass, server, share, nameForTestR
 	Expect(sc).NotTo(BeNil())
 	Expect(sc.Name).To(Equal(nameForTestResource))
 	Expect(sc.Finalizers).To(HaveLen(1))
-	Expect(sc.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+	Expect(sc.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 	Expect(sc.Provisioner).To(Equal(controller.NFSStorageClassProvisioner))
 	Expect(*sc.ReclaimPolicy).To(Equal(corev1.PersistentVolumeReclaimDelete))
 	Expect(*sc.VolumeBindingMode).To(Equal(v1.VolumeBindingWaitForFirstConsumer))
@@ -440,5 +440,5 @@ func performStandartChecksForSecret(secret *corev1.Secret, nameForTestResource, 
 	Expect(secret.Name).To(Equal(controller.SecretForMountOptionsPrefix + nameForTestResource))
 	Expect(secret.Namespace).To(Equal(controllerNamespace))
 	Expect(secret.Finalizers).To(HaveLen(1))
-	Expect(secret.Finalizers).To(ContainElement(controller.NFSStorageClassFinalizerName))
+	Expect(secret.Finalizers).To(ContainElement(controller.NFSStorageClassControllerFinalizerName))
 }

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
@@ -116,6 +116,23 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 
 	})
 
+	It("Annotate_sc_as_default_sc", func() {
+		sc := &v1.StorageClass{}
+		err := cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Annotations).To(BeNil())
+
+		sc.Annotations = map[string]string{
+			controller.StorageClassDefaultAnnotationKey: controller.StorageClassDefaultAnnotationValTrue,
+		}
+
+		err = cl.Update(ctx, sc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Annotations).To(HaveLen(1))
+		Expect(sc.Annotations).To(HaveKeyWithValue(controller.StorageClassDefaultAnnotationKey, controller.StorageClassDefaultAnnotationValTrue))
+
+	})
+
 	It("Update_nfs_sc_1", func() {
 		nsc := &v1alpha1.NFSStorageClass{}
 		err := cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, nsc)
@@ -162,6 +179,15 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		Expect(err).NotTo(HaveOccurred())
 		performStandartChecksForSecret(secret, nameForTestResource, controllerNamespace)
 		Expect(secret.StringData).To(HaveKeyWithValue(controller.MountOptionsSecretKey, fmt.Sprintf("%s,%s,%s,%s,%s", mountOptForNFSVer, mountModeUpdated, mountOptForTimeout, mountOptForRetransmissions, mountOptForReadOnlyTrue)))
+
+	})
+
+	It("Check_anotated_sc_after_nsc_update", func() {
+		sc := &v1.StorageClass{}
+		err := cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Annotations).To(HaveLen(1))
+		Expect(sc.Annotations).To(HaveKeyWithValue(controller.StorageClassDefaultAnnotationKey, controller.StorageClassDefaultAnnotationValTrue))
 
 	})
 

--- a/images/webhooks/src/handlers/scValidator.go
+++ b/images/webhooks/src/handlers/scValidator.go
@@ -18,7 +18,9 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"k8s.io/klog/v2"
 
@@ -46,8 +48,24 @@ func SCValidate(ctx context.Context, arReview *model.AdmissionReview, obj metav1
 			return &kwhvalidating.ValidatorResult{Valid: true},
 				nil
 		} else {
+			if arReview.Operation == model.OperationUpdate {
+				changed, err := isStorageClassChangedExceptAnnotations(arReview.OldObjectRaw, arReview.NewObjectRaw)
+				if err != nil {
+					return nil, err
+				}
+
+				if !changed {
+					klog.Infof("User %s is allowed to change annotations for storage classes with provisioner %s", arReview.UserInfo.Username, NFSStorageClassProvisioner)
+					return &kwhvalidating.ValidatorResult{Valid: true},
+						nil
+				}
+			}
+
 			klog.Infof("User %s is not allowed to manage storage classes with provisioner %s", arReview.UserInfo.Username, NFSStorageClassProvisioner)
-			return &kwhvalidating.ValidatorResult{Valid: false, Message: fmt.Sprintf("Manual operations with the StorageClass that uses the %s provisioner are not allowed. Please use NFSStorageClass instead.", NFSStorageClassProvisioner)},
+			return &kwhvalidating.ValidatorResult{
+					Valid:   false,
+					Message: fmt.Sprintf("Direct modifications to the StorageClass (other than annotations) with the provisioner %s are not allowed. Please use NFSStorageClass for such operations.", NFSStorageClassProvisioner),
+				},
 				nil
 		}
 	} else {
@@ -55,4 +73,72 @@ func SCValidate(ctx context.Context, arReview *model.AdmissionReview, obj metav1
 			nil
 	}
 
+}
+
+func isStorageClassChangedExceptAnnotations(oldObjectRaw, newObjectRaw []byte) (bool, error) {
+	var oldSC, newSC storagev1.StorageClass
+
+	if err := json.Unmarshal(oldObjectRaw, &oldSC); err != nil {
+		err := fmt.Errorf("failed to unmarshal old object: %v", err)
+		return false, err
+	}
+
+	if err := json.Unmarshal(newObjectRaw, &newSC); err != nil {
+		err := fmt.Errorf("failed to unmarshal new object: %v", err)
+		return false, err
+	}
+
+	klog.Info("=====================================")
+	klog.Infof("Comparing old object: %+v", oldSC)
+	klog.Info("=====================================")
+	klog.Infof("Comparing new object: %+v", newSC)
+	klog.Info("=====================================")
+
+	if oldSC.Provisioner != newSC.Provisioner {
+		klog.Infof("Provisioner changed from %s to %s", oldSC.Provisioner, newSC.Provisioner)
+		return true, nil
+	}
+
+	if *oldSC.VolumeBindingMode != *newSC.VolumeBindingMode {
+		klog.Infof("VolumeBindingMode changed from %s to %s", *oldSC.VolumeBindingMode, *newSC.VolumeBindingMode)
+		return true, nil
+	}
+
+	if *oldSC.ReclaimPolicy != *newSC.ReclaimPolicy {
+		klog.Infof("ReclaimPolicy changed from %s to %s", *oldSC.ReclaimPolicy, *newSC.ReclaimPolicy)
+		return true, nil
+	}
+
+	if !reflect.DeepEqual(oldSC.Parameters, newSC.Parameters) {
+		klog.Infof("Parameters changed from %v to %v", oldSC.Parameters, newSC.Parameters)
+		return true, nil
+	}
+
+	if *oldSC.AllowVolumeExpansion != *newSC.AllowVolumeExpansion {
+		klog.Infof("AllowVolumeExpansion changed from %v to %v", *oldSC.AllowVolumeExpansion, *newSC.AllowVolumeExpansion)
+		return true, nil
+	}
+
+	if !reflect.DeepEqual(oldSC.MountOptions, newSC.MountOptions) {
+		klog.Infof("MountOptions changed from %v to %v", oldSC.MountOptions, newSC.MountOptions)
+		return true, nil
+	}
+
+	if !reflect.DeepEqual(oldSC.AllowedTopologies, newSC.AllowedTopologies) {
+		klog.Infof("AllowedTopologies changed from %v to %v", oldSC.AllowedTopologies, newSC.AllowedTopologies)
+		return true, nil
+	}
+
+	newSC.ObjectMeta.Annotations = nil
+	oldSC.ObjectMeta.Annotations = nil
+
+	newSC.ObjectMeta.ManagedFields = nil
+	oldSC.ObjectMeta.ManagedFields = nil
+
+	if !reflect.DeepEqual(oldSC.ObjectMeta, newSC.ObjectMeta) {
+		klog.Infof("ObjectMeta changed from %+v to %+v", oldSC.ObjectMeta, newSC.ObjectMeta)
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/templates/controller/rbac-for-us.yaml
+++ b/templates/controller/rbac-for-us.yaml
@@ -10,7 +10,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: controller
+  name: d8:{{ .Chart.Name }}:controller
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "controller")) | nindent 2 }}
 rules:
@@ -60,7 +60,6 @@ rules:
       - get
       - list
       - create
-      - delete
       - watch
       - update
   - apiGroups:
@@ -78,7 +77,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: controller
+  name: d8:{{ .Chart.Name }}:controller
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "controller")) | nindent 2 }}
 subjects:
@@ -87,7 +86,7 @@ subjects:
     namespace: d8-{{ .Chart.Name }}
 roleRef:
   kind: Role
-  name: controller
+  name: d8:{{ .Chart.Name }}:controller
   apiGroup: rbac.authorization.k8s.io
 
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR introduces several improvements, with the most important being the fix for the StorageClass validation webhook. Now, users can set annotations on StorageClasses with the provisioner `nfs.csi.k8s.io`, which is essential for making a StorageClass the default. Additionally, the PR includes fixes for RBAC configurations for the controller.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The main issue addressed by this PR is the inability to set annotations on StorageClasses with the `nfs.csi.k8s.io` provisioner. This prevented users from setting a default StorageClass. Fixing the validation webhook resolves this problem, providing greater flexibility and functionality. The RBAC fixes ensure that the controller has the necessary permissions to operate correctly.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Users can now set annotations on StorageClasses with the provisioner `nfs.csi.k8s.io`, allowing them to designate a default StorageClass.
- The controller operates with the correct permissions due to the updated RBAC configurations.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
