### PR TITLE
[docs] Add comment about enabling v3 verion in moduleconfig

### DIFF
--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -13,4 +13,4 @@ properties:
   v3support:
     type: boolean
     default: false
-    description: NFS version v3 support
+    description: NFS version v3 support. After enabling this setting, rpc-statd will be installed on nodes. When this setting is disabled, it will NOT be removed from the nodes.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add comment about enabling v3 verion in moduleconfig. After enabling there will be rpc-statd installed on all nodes

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct docs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
