### PR TITLE
[csi] Add patch for fake volume expansion support

### DIFF
--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -20,7 +20,7 @@ index 726df875..e52d90a7 100644
  func (cs *ControllerServer) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 -	return nil, status.Error(codes.Unimplemented, "")
 +	return &csi.GetCapacityResponse{
-+		AvailableCapacity: 2000_000_000_000_000, // 1000 TB
++		AvailableCapacity: 7000_000_000_000_000, // 1000 TB
 +		MaximumVolumeSize: nil,
 +		MinimumVolumeSize: nil,
 +	}, nil

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -20,7 +20,7 @@ index 726df875..e52d90a7 100644
  func (cs *ControllerServer) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 -	return nil, status.Error(codes.Unimplemented, "")
 +	return &csi.GetCapacityResponse{
-+		AvailableCapacity: 1000_000_000_000_000, // 1000 TB
++		AvailableCapacity: 2000_000_000_000_000, // 1000 TB
 +		MaximumVolumeSize: nil,
 +		MinimumVolumeSize: nil,
 +	}, nil

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -1,0 +1,50 @@
+From 9c4072bca5d0bf8bf0fa5caff20d0dadd211fd5b Mon Sep 17 00:00:00 2001
+From: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
+Date: Mon, 23 Sep 2024 17:40:34 +0300
+Subject: [PATCH] fake implementation of ControllerExpandVolume
+
+Signed-off-by: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
+---
+ pkg/nfs/controllerserver.go | 13 +++++++++++--
+ pkg/nfs/nfs.go              |  1 +
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/pkg/nfs/controllerserver.go b/pkg/nfs/controllerserver.go
+index 726df875..be412fda 100644
+--- a/pkg/nfs/controllerserver.go
++++ b/pkg/nfs/controllerserver.go
+@@ -432,8 +432,17 @@ func (cs *ControllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshot
+ 	return nil, status.Error(codes.Unimplemented, "")
+ }
+ 
+-func (cs *ControllerServer) ControllerExpandVolume(_ context.Context, _ *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+-	return nil, status.Error(codes.Unimplemented, "")
++func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
++	// fake implementation, doesn't really resize anything
++
++	klog.V(2).Infof("received expansion request for volumeID:%s, requiredBytes: %d", req.VolumeId, req.CapacityRange.RequiredBytes)
++	klog.Warning("volume expansion is not really happenning, fake implementation is used")
++
++	// TODO: check that requested capacity is not lower then the current one
++	return &csi.ControllerExpandVolumeResponse{
++		CapacityBytes:         req.CapacityRange.RequiredBytes,
++		NodeExpansionRequired: false,
++	}, nil
+ }
+ 
+ // Mount nfs server at base-dir
+diff --git a/pkg/nfs/nfs.go b/pkg/nfs/nfs.go
+index 7d69265e..0025782c 100644
+--- a/pkg/nfs/nfs.go
++++ b/pkg/nfs/nfs.go
+@@ -98,6 +98,7 @@ func NewDriver(options *DriverOptions) *Driver {
+ 		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+ 		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+ 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
++		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+ 	})
+ 
+ 	n.AddNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
+-- 
+2.43.0
+

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -1,4 +1,4 @@
-From 1899bba86778124ec86f8d284afe11261f5f0072 Mon Sep 17 00:00:00 2001
+From 2788d323ac8c5077432e80d4c50f0898bd82f59d Mon Sep 17 00:00:00 2001
 From: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 Date: Mon, 23 Sep 2024 17:40:34 +0300
 Subject: [PATCH] fake implementation of ControllerExpandVolume
@@ -6,8 +6,8 @@ Subject: [PATCH] fake implementation of ControllerExpandVolume
 Signed-off-by: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 ---
  pkg/nfs/controllerserver.go | 19 ++++++++++++++++---
- pkg/nfs/nfs.go              |  1 +
- 2 files changed, 17 insertions(+), 3 deletions(-)
+ pkg/nfs/nfs.go              |  2 ++
+ 2 files changed, 18 insertions(+), 3 deletions(-)
 
 diff --git a/pkg/nfs/controllerserver.go b/pkg/nfs/controllerserver.go
 index 726df875..664ce571 100644
@@ -47,13 +47,14 @@ index 726df875..664ce571 100644
  
  // Mount nfs server at base-dir
 diff --git a/pkg/nfs/nfs.go b/pkg/nfs/nfs.go
-index 7d69265e..0025782c 100644
+index 7d69265e..e91093da 100644
 --- a/pkg/nfs/nfs.go
 +++ b/pkg/nfs/nfs.go
-@@ -98,6 +98,7 @@ func NewDriver(options *DriverOptions) *Driver {
+@@ -98,6 +98,8 @@ func NewDriver(options *DriverOptions) *Driver {
  		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
  		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
  		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
++		csi.ControllerServiceCapability_RPC_GET_CAPACITY,
 +		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
  	})
  

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -1,16 +1,17 @@
-From 2788d323ac8c5077432e80d4c50f0898bd82f59d Mon Sep 17 00:00:00 2001
+From 94eec39d2b3e455487546889c70bb2651e5abb29 Mon Sep 17 00:00:00 2001
 From: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
-Date: Mon, 23 Sep 2024 17:40:34 +0300
-Subject: [PATCH] fake implementation of ControllerExpandVolume
+Date: Tue, 24 Sep 2024 09:56:28 +0300
+Subject: [PATCH] fake-implementation-of-ControllerExpandVolume
 
 Signed-off-by: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 ---
  pkg/nfs/controllerserver.go | 19 ++++++++++++++++---
+ pkg/nfs/identityserver.go   | 14 ++++++++++++++
  pkg/nfs/nfs.go              |  2 ++
- 2 files changed, 18 insertions(+), 3 deletions(-)
+ 3 files changed, 32 insertions(+), 3 deletions(-)
 
 diff --git a/pkg/nfs/controllerserver.go b/pkg/nfs/controllerserver.go
-index 726df875..664ce571 100644
+index 726df875..e52d90a7 100644
 --- a/pkg/nfs/controllerserver.go
 +++ b/pkg/nfs/controllerserver.go
 @@ -304,7 +304,11 @@ func (cs *ControllerServer) ListVolumes(_ context.Context, _ *csi.ListVolumesReq
@@ -46,6 +47,31 @@ index 726df875..664ce571 100644
  }
  
  // Mount nfs server at base-dir
+diff --git a/pkg/nfs/identityserver.go b/pkg/nfs/identityserver.go
+index d76fcf49..85afdb6f 100644
+--- a/pkg/nfs/identityserver.go
++++ b/pkg/nfs/identityserver.go
+@@ -61,6 +61,20 @@ func (ids *IdentityServer) GetPluginCapabilities(_ context.Context, _ *csi.GetPl
+ 					},
+ 				},
+ 			},
++			{
++				Type: &csi.PluginCapability_VolumeExpansion_{
++					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
++						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
++					},
++				},
++			},
++			{
++				Type: &csi.PluginCapability_VolumeExpansion_{
++					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
++						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
++					},
++				},
++			},
+ 		},
+ 	}, nil
+ }
 diff --git a/pkg/nfs/nfs.go b/pkg/nfs/nfs.go
 index 7d69265e..e91093da 100644
 --- a/pkg/nfs/nfs.go

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -1,19 +1,32 @@
-From 9c4072bca5d0bf8bf0fa5caff20d0dadd211fd5b Mon Sep 17 00:00:00 2001
+From 1899bba86778124ec86f8d284afe11261f5f0072 Mon Sep 17 00:00:00 2001
 From: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 Date: Mon, 23 Sep 2024 17:40:34 +0300
 Subject: [PATCH] fake implementation of ControllerExpandVolume
 
 Signed-off-by: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 ---
- pkg/nfs/controllerserver.go | 13 +++++++++++--
+ pkg/nfs/controllerserver.go | 19 ++++++++++++++++---
  pkg/nfs/nfs.go              |  1 +
- 2 files changed, 12 insertions(+), 2 deletions(-)
+ 2 files changed, 17 insertions(+), 3 deletions(-)
 
 diff --git a/pkg/nfs/controllerserver.go b/pkg/nfs/controllerserver.go
-index 726df875..be412fda 100644
+index 726df875..664ce571 100644
 --- a/pkg/nfs/controllerserver.go
 +++ b/pkg/nfs/controllerserver.go
-@@ -432,8 +432,17 @@ func (cs *ControllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshot
+@@ -304,7 +304,11 @@ func (cs *ControllerServer) ListVolumes(_ context.Context, _ *csi.ListVolumesReq
+ }
+ 
+ func (cs *ControllerServer) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+-	return nil, status.Error(codes.Unimplemented, "")
++	return &csi.GetCapacityResponse{
++		AvailableCapacity: 1000000,
++		MaximumVolumeSize: nil,
++		MinimumVolumeSize: nil,
++	}, nil
+ }
+ 
+ // ControllerGetCapabilities implements the default GRPC callout.
+@@ -432,8 +436,17 @@ func (cs *ControllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshot
  	return nil, status.Error(codes.Unimplemented, "")
  }
  

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -19,7 +19,7 @@ index 726df875..664ce571 100644
  func (cs *ControllerServer) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 -	return nil, status.Error(codes.Unimplemented, "")
 +	return &csi.GetCapacityResponse{
-+		AvailableCapacity: 1000000,
++		AvailableCapacity: 1000_000_000_000_000, // 1000 TB
 +		MaximumVolumeSize: nil,
 +		MinimumVolumeSize: nil,
 +	}, nil

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -1,17 +1,18 @@
-From 94eec39d2b3e455487546889c70bb2651e5abb29 Mon Sep 17 00:00:00 2001
+From a0559518013f75a873ba616a3cdee597a1b59135 Mon Sep 17 00:00:00 2001
 From: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 Date: Tue, 24 Sep 2024 09:56:28 +0300
 Subject: [PATCH] fake-implementation-of-ControllerExpandVolume
 
 Signed-off-by: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 ---
- pkg/nfs/controllerserver.go | 19 ++++++++++++++++---
+ pkg/nfs/controllerserver.go | 18 +++++++++++++++---
  pkg/nfs/identityserver.go   | 14 ++++++++++++++
- pkg/nfs/nfs.go              |  2 ++
- 3 files changed, 32 insertions(+), 3 deletions(-)
+ pkg/nfs/nfs.go              |  3 +++
+ pkg/nfs/nodeserver.go       | 12 ++++++++++--
+ 4 files changed, 42 insertions(+), 5 deletions(-)
 
 diff --git a/pkg/nfs/controllerserver.go b/pkg/nfs/controllerserver.go
-index 726df875..e52d90a7 100644
+index 726df875..494567de 100644
 --- a/pkg/nfs/controllerserver.go
 +++ b/pkg/nfs/controllerserver.go
 @@ -304,7 +304,11 @@ func (cs *ControllerServer) ListVolumes(_ context.Context, _ *csi.ListVolumesReq
@@ -20,26 +21,25 @@ index 726df875..e52d90a7 100644
  func (cs *ControllerServer) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 -	return nil, status.Error(codes.Unimplemented, "")
 +	return &csi.GetCapacityResponse{
-+		AvailableCapacity: 7000_000_000_000_000, // 1000 TB
++		AvailableCapacity: 1000_000_000_000_000, // 1000 TB
 +		MaximumVolumeSize: nil,
 +		MinimumVolumeSize: nil,
 +	}, nil
  }
  
  // ControllerGetCapabilities implements the default GRPC callout.
-@@ -432,8 +436,17 @@ func (cs *ControllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshot
+@@ -432,8 +436,16 @@ func (cs *ControllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshot
  	return nil, status.Error(codes.Unimplemented, "")
  }
  
 -func (cs *ControllerServer) ControllerExpandVolume(_ context.Context, _ *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 -	return nil, status.Error(codes.Unimplemented, "")
-+func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
++func (cs *ControllerServer) ControllerExpandVolume(_ context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 +	// fake implementation, doesn't really resize anything
 +
-+	klog.V(2).Infof("received expansion request for volumeID:%s, requiredBytes: %d", req.VolumeId, req.CapacityRange.RequiredBytes)
-+	klog.Warning("volume expansion is not really happenning, fake implementation is used")
++	klog.V(2).Infof("[ControllerExpandVolume] received expansion request for volumeID:%s, requiredBytes: %d", req.VolumeId, req.CapacityRange.RequiredBytes)
++	klog.Warning("[ControllerExpandVolume] volume expansion is not really happenning, fake implementation is used")
 +
-+	// TODO: check that requested capacity is not lower then the current one
 +	return &csi.ControllerExpandVolumeResponse{
 +		CapacityBytes:         req.CapacityRange.RequiredBytes,
 +		NodeExpansionRequired: false,
@@ -73,10 +73,10 @@ index d76fcf49..85afdb6f 100644
  	}, nil
  }
 diff --git a/pkg/nfs/nfs.go b/pkg/nfs/nfs.go
-index 7d69265e..e91093da 100644
+index 7d69265e..b57f8d83 100644
 --- a/pkg/nfs/nfs.go
 +++ b/pkg/nfs/nfs.go
-@@ -98,6 +98,8 @@ func NewDriver(options *DriverOptions) *Driver {
+@@ -98,12 +98,15 @@ func NewDriver(options *DriverOptions) *Driver {
  		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
  		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
  		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
@@ -85,6 +85,36 @@ index 7d69265e..e91093da 100644
  	})
  
  	n.AddNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
+ 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+ 		csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+ 		csi.NodeServiceCapability_RPC_UNKNOWN,
++		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+ 	})
+ 	n.volumeLocks = NewVolumeLocks()
+ 
+diff --git a/pkg/nfs/nodeserver.go b/pkg/nfs/nodeserver.go
+index 76e0d675..c4667a43 100644
+--- a/pkg/nfs/nodeserver.go
++++ b/pkg/nfs/nodeserver.go
+@@ -292,8 +292,16 @@ func (ns *NodeServer) NodeStageVolume(_ context.Context, _ *csi.NodeStageVolumeR
+ }
+ 
+ // NodeExpandVolume node expand volume
+-func (ns *NodeServer) NodeExpandVolume(_ context.Context, _ *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+-	return nil, status.Error(codes.Unimplemented, "")
++func (ns *NodeServer) NodeExpandVolume(_ context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
++	klog.V(2).Infof(
++		"[NodeExpandVolume] received expansion request for volumeID:%s, path: %s, requiredBytes: %d",
++		req.VolumeId,
++		req.VolumePath,
++		req.CapacityRange.RequiredBytes,
++	)
++	klog.Warning("[NodeExpandVolume] volume expansion is not really happenning, fake implementation is used")
++
++	return &csi.NodeExpandVolumeResponse{}, nil
+ }
+ 
+ func makeDir(pathname string) error {
 -- 
 2.43.0
 

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -1,4 +1,4 @@
-From a0559518013f75a873ba616a3cdee597a1b59135 Mon Sep 17 00:00:00 2001
+From dd972d0dfcac76558973ce4f07243f8c50771d3f Mon Sep 17 00:00:00 2001
 From: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 Date: Tue, 24 Sep 2024 09:56:28 +0300
 Subject: [PATCH] fake-implementation-of-ControllerExpandVolume
@@ -7,9 +7,9 @@ Signed-off-by: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 ---
  pkg/nfs/controllerserver.go | 18 +++++++++++++++---
  pkg/nfs/identityserver.go   | 14 ++++++++++++++
- pkg/nfs/nfs.go              |  3 +++
- pkg/nfs/nodeserver.go       | 12 ++++++++++--
- 4 files changed, 42 insertions(+), 5 deletions(-)
+ pkg/nfs/nfs.go              |  2 ++
+ pkg/nfs/nodeserver.go       |  2 +-
+ 4 files changed, 32 insertions(+), 4 deletions(-)
 
 diff --git a/pkg/nfs/controllerserver.go b/pkg/nfs/controllerserver.go
 index 726df875..494567de 100644
@@ -73,10 +73,10 @@ index d76fcf49..85afdb6f 100644
  	}, nil
  }
 diff --git a/pkg/nfs/nfs.go b/pkg/nfs/nfs.go
-index 7d69265e..b57f8d83 100644
+index 7d69265e..e91093da 100644
 --- a/pkg/nfs/nfs.go
 +++ b/pkg/nfs/nfs.go
-@@ -98,12 +98,15 @@ func NewDriver(options *DriverOptions) *Driver {
+@@ -98,6 +98,8 @@ func NewDriver(options *DriverOptions) *Driver {
  		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
  		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
  		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
@@ -85,36 +85,19 @@ index 7d69265e..b57f8d83 100644
  	})
  
  	n.AddNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
- 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
- 		csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
- 		csi.NodeServiceCapability_RPC_UNKNOWN,
-+		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
- 	})
- 	n.volumeLocks = NewVolumeLocks()
- 
 diff --git a/pkg/nfs/nodeserver.go b/pkg/nfs/nodeserver.go
-index 76e0d675..c4667a43 100644
+index 76e0d675..98809030 100644
 --- a/pkg/nfs/nodeserver.go
 +++ b/pkg/nfs/nodeserver.go
-@@ -292,8 +292,16 @@ func (ns *NodeServer) NodeStageVolume(_ context.Context, _ *csi.NodeStageVolumeR
+@@ -292,7 +292,7 @@ func (ns *NodeServer) NodeStageVolume(_ context.Context, _ *csi.NodeStageVolumeR
  }
  
  // NodeExpandVolume node expand volume
 -func (ns *NodeServer) NodeExpandVolume(_ context.Context, _ *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
--	return nil, status.Error(codes.Unimplemented, "")
 +func (ns *NodeServer) NodeExpandVolume(_ context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-+	klog.V(2).Infof(
-+		"[NodeExpandVolume] received expansion request for volumeID:%s, path: %s, requiredBytes: %d",
-+		req.VolumeId,
-+		req.VolumePath,
-+		req.CapacityRange.RequiredBytes,
-+	)
-+	klog.Warning("[NodeExpandVolume] volume expansion is not really happenning, fake implementation is used")
-+
-+	return &csi.NodeExpandVolumeResponse{}, nil
+ 	return nil, status.Error(codes.Unimplemented, "")
  }
  
- func makeDir(pathname string) error {
 -- 
 2.43.0
 

--- a/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
+++ b/images/csi-nfs/patches/0003-fake-implementation-of-ControllerExpandVolume.patch
@@ -1,4 +1,4 @@
-From dd972d0dfcac76558973ce4f07243f8c50771d3f Mon Sep 17 00:00:00 2001
+From 189c10ff76dcef64cf2816317d3c197956497453 Mon Sep 17 00:00:00 2001
 From: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
 Date: Tue, 24 Sep 2024 09:56:28 +0300
 Subject: [PATCH] fake-implementation-of-ControllerExpandVolume
@@ -8,8 +8,7 @@ Signed-off-by: Alexandr Stefurishin <alexandr.stefurishin@flant.com>
  pkg/nfs/controllerserver.go | 18 +++++++++++++++---
  pkg/nfs/identityserver.go   | 14 ++++++++++++++
  pkg/nfs/nfs.go              |  2 ++
- pkg/nfs/nodeserver.go       |  2 +-
- 4 files changed, 32 insertions(+), 4 deletions(-)
+ 3 files changed, 31 insertions(+), 3 deletions(-)
 
 diff --git a/pkg/nfs/controllerserver.go b/pkg/nfs/controllerserver.go
 index 726df875..494567de 100644
@@ -85,19 +84,6 @@ index 7d69265e..e91093da 100644
  	})
  
  	n.AddNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
-diff --git a/pkg/nfs/nodeserver.go b/pkg/nfs/nodeserver.go
-index 76e0d675..98809030 100644
---- a/pkg/nfs/nodeserver.go
-+++ b/pkg/nfs/nodeserver.go
-@@ -292,7 +292,7 @@ func (ns *NodeServer) NodeStageVolume(_ context.Context, _ *csi.NodeStageVolumeR
- }
- 
- // NodeExpandVolume node expand volume
--func (ns *NodeServer) NodeExpandVolume(_ context.Context, _ *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-+func (ns *NodeServer) NodeExpandVolume(_ context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
- 	return nil, status.Error(codes.Unimplemented, "")
- }
- 
 -- 
 2.43.0
 

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -9,13 +9,14 @@
 image: {{ $.ImageName }}-golang-artifact
 from: {{ $.BASE_GOLANG }}
 final: false
+fromCacheVersion: 20240923201359
 
 git:
   - add: /images/{{ $.ImageName }}
     to: /
     stageDependencies:
       setup:
-        - "images/csi-nfs/**/*"
+        - "**/*"
     includePaths:
     - patches
 

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -15,8 +15,8 @@ git:
   - add: /images/{{ $.ImageName }}
     to: /
     stageDependencies:
-      setup:
-        - "images/csi-nfs/**/*"
+      install:
+        - "**/*"
     includePaths:
     - patches
 

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     to: /
     stageDependencies:
       setup:
-        - "**/*"
+        - "images/csi-nfs/**/*"
     includePaths:
     - patches
 

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -29,7 +29,7 @@ shell:
     - export GOPROXY={{ env "GOPROXY" }}
     - git clone --depth 1 --branch v{{ $version }} {{ env "SOURCE_REPO" }}/kubernetes-csi/csi-driver-nfs.git /csi-driver-nfs
     - cd /csi-driver-nfs
-    - for patchfile in /patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; done
+    - for patchfile in /images/csi-nfs/patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; done
     - cd /csi-driver-nfs/cmd/nfsplugin
     - go mod vendor
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /nfsplugin

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -29,10 +29,9 @@ shell:
     - export GOPROXY={{ env "GOPROXY" }}
     - git clone --depth 1 --branch v{{ $version }} {{ env "SOURCE_REPO" }}/kubernetes-csi/csi-driver-nfs.git /csi-driver-nfs
     - cd /csi-driver-nfs
-    - for patchfile in /patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; exit 1; done
-    - cd /csi-driver-nfs/cmd/nfsplugin
+    - for patchfile in /patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; done
     - go mod vendor
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /nfsplugin
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /nfsplugin cmd/nfsplugin
     - chmod +x /nfsplugin
 
 ---

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -9,7 +9,7 @@
 image: {{ $.ImageName }}-golang-artifact
 from: {{ $.BASE_GOLANG }}
 final: false
-fromCacheVersion: 20240923201359
+fromCacheVersion: 20240924092250
 
 git:
   - add: /images/{{ $.ImageName }}

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -15,7 +15,7 @@ git:
     to: /
     stageDependencies:
       setup:
-        - "**/*"
+        - "images/csi-nfs/**/*"
     includePaths:
     - patches
 

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -9,7 +9,7 @@
 image: {{ $.ImageName }}-golang-artifact
 from: {{ $.BASE_GOLANG }}
 final: false
-fromCacheVersion: 20240924092250
+fromCacheVersion: 20240924100030
 
 git:
   - add: /images/{{ $.ImageName }}

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -29,7 +29,7 @@ shell:
     - export GOPROXY={{ env "GOPROXY" }}
     - git clone --depth 1 --branch v{{ $version }} {{ env "SOURCE_REPO" }}/kubernetes-csi/csi-driver-nfs.git /csi-driver-nfs
     - cd /csi-driver-nfs
-    - for patchfile in /images/csi-nfs/patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; done
+    - for patchfile in /patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; done
     - cd /csi-driver-nfs/cmd/nfsplugin
     - go mod vendor
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /nfsplugin

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -29,7 +29,7 @@ shell:
     - export GOPROXY={{ env "GOPROXY" }}
     - git clone --depth 1 --branch v{{ $version }} {{ env "SOURCE_REPO" }}/kubernetes-csi/csi-driver-nfs.git /csi-driver-nfs
     - cd /csi-driver-nfs
-    - for patchfile in /patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; done
+    - for patchfile in /patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; exit 1; done
     - cd /csi-driver-nfs/cmd/nfsplugin
     - go mod vendor
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /nfsplugin

--- a/images/csi-nfs/werf.inc.yaml
+++ b/images/csi-nfs/werf.inc.yaml
@@ -31,7 +31,7 @@ shell:
     - cd /csi-driver-nfs
     - for patchfile in /patches/*.patch ; do echo -n "Apply ${patchfile} ... "; git apply ${patchfile}; done
     - go mod vendor
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /nfsplugin cmd/nfsplugin
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /nfsplugin ./cmd/nfsplugin
     - chmod +x /nfsplugin
 
 ---

--- a/templates/csi/controller.yaml
+++ b/templates/csi/controller.yaml
@@ -45,7 +45,7 @@
 {{- $csiControllerConfig := dict }}
 {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
 {{- $_ := set $csiControllerConfig "snapshotterEnabled" true }}
-{{- $_ := set $csiControllerConfig "resizerEnabled" false }}
+{{- $_ := set $csiControllerConfig "resizerEnabled" true }}
 {{- $_ := set $csiControllerConfig "provisionerTimeout" "1200s" }}
 {{- $_ := set $csiControllerConfig "snapshotterTimeout" "1200s" }}
 {{- $_ := set $csiControllerConfig "extraCreateMetadataEnabled" true }}


### PR DESCRIPTION
## Description
Proposed patch will add fake support for NFS volume expansion. Implementation won't do any real volume change (it's impossible in NFS).

## Why do we need it, and what problem does it solve?
Solves some exotic client-specific scenarios.

## What is the expected result?
We should be able to change volume size in PVC and see it's being changed in status.

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.
