### PR TITLE
[bashible] Fix rpcbind installation and startup on ALT Linux, CentOS, and Debian`

### DIFF
--- a/templates/nodegroupconfiguration-nfs-common-install-altlinux.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-altlinux.yaml
@@ -26,5 +26,6 @@ spec:
 
     apt-get install rpcbind nfs-utils
     systemctl start rpcbind
+    systemctl start rpc-statd.service
     systemctl enable rpcbind
 {{- end }}

--- a/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
@@ -24,7 +24,7 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    bb-yum-install "nfs-utils"
+    bb-yum-install "nfs-utils" "rpcbind"
     # This is dirty hack for statd, because it can't be enabled via systemd in newer distributive (Bashible performs a full cycle at every node reboot, so statd will be started)
     systemctl start rpc-statd.service
 {{- end }}

--- a/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
@@ -25,6 +25,7 @@ spec:
     # limitations under the License.
 
     bb-yum-install "nfs-utils" "rpcbind"
+    
     # This is dirty hack for statd, because it can't be enabled via systemd in newer distributive (Bashible performs a full cycle at every node reboot, so statd will be started)
     systemctl start rpc-statd.service
 {{- end }}

--- a/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
@@ -25,6 +25,7 @@ spec:
     # limitations under the License.
 
     bb-apt-install "nfs-common" "rpcbind"
+    
     # This is dirty hack for statd, because it can't be enabled via systemd in newer distributive (Bashible performs a full cycle at every node reboot, so statd will be started)
     systemctl start rpc-statd.service
 {{- end }}

--- a/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
@@ -24,7 +24,7 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    bb-apt-install "nfs-common"
+    bb-apt-install "nfs-common" "rpcbind"
     # This is dirty hack for statd, because it can't be enabled via systemd in newer distributive (Bashible performs a full cycle at every node reboot, so statd will be started)
     systemctl start rpc-statd.service
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR resolves issues with the installation and startup of `rpcbind` across multiple Linux distributions, specifically ALT Linux, CentOS, and Debian. Adjustments were made to ensure `rpcbind` installs and starts correctly on each of these distributions.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The installation and startup process for `rpcbind` was previously inconsistent across different Linux distributions, leading to failures in environments that depend on `rpcbind` services. This fix ensures compatibility and reliable setup across the specified distributions.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- `rpcbind` installs and starts successfully on ALT Linux, CentOS, and Debian.
- Consistent and reliable behavior of `rpcbind`-dependent services across these distributions.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
