### PR TITLE
[scheduler] get all pvcs in shouldProcessPod

### DIFF
--- a/images/csi-nfs-scheduler-extender/src/pkg/scheduler/func.go
+++ b/images/csi-nfs-scheduler-extender/src/pkg/scheduler/func.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"fmt"
 
-	"csi-nfs-scheduler-extender/pkg/logger"
 	v1alpha1 "github.com/deckhouse/csi-nfs/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"csi-nfs-scheduler-extender/pkg/logger"
 )
 
 const (

--- a/images/csi-nfs-scheduler-extender/src/pkg/scheduler/func.go
+++ b/images/csi-nfs-scheduler-extender/src/pkg/scheduler/func.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	"csi-nfs-scheduler-extender/pkg/logger"
 	v1alpha1 "github.com/deckhouse/csi-nfs/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"csi-nfs-scheduler-extender/pkg/logger"
 )
 
 const (
@@ -52,13 +51,13 @@ func shouldProcessPod(ctx context.Context, cl client.Client, log logger.Logger, 
 	pvcs := &corev1.PersistentVolumeClaimList{}
 	err := cl.List(ctx, pvcs, client.InNamespace(pod.Namespace))
 	if err != nil {
-        return false, nil, fmt.Errorf("[ShouldProcessPod] error getting PVCs in namespace %s: %v", pod.Namespace, err)
-    }
+		return false, nil, fmt.Errorf("[ShouldProcessPod] error getting PVCs in namespace %s: %v", pod.Namespace, err)
+	}
 
 	pvcMap := make(map[string]*corev1.PersistentVolumeClaim, len(pvcs.Items))
-    for _, pvc := range pvcs.Items {
-        pvcMap[pvc.Name] = &pvc
-    }
+	for _, pvc := range pvcs.Items {
+		pvcMap[pvc.Name] = &pvc
+	}
 
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim == nil {


### PR DESCRIPTION
## Description
In the `shouldProcessPod` method, we currently iterate over pod volumes and fetch each PVC with a separate HTTP request.
The proposed code improvement involves creating a pvcMap with the format 'pvcName: pvcStruct' using a single HTTP request.

## Why do we need it, and what problem does it solve?
The issue lies in making multiple unnecessary HTTP requests. The suggested improvement reduces this to a single request.

## What is the expected result?
The functionality remains unchanged, but the network load is significantly reduced.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
