### PR TITLE
[internal] add volumesnapshot controller mount options and storage classes annotations

### DIFF
--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -277,7 +277,7 @@ func RunEventReconcile(ctx context.Context, cl client.Client, log logger.Logger,
 		return true, err
 	}
 
-	reconcileTypeForVSClass, oldVSClass, newVSClass := IdentifyReconcileFuncForVSClass(log, vsClassList, nsc, controllerNamespace)
+	reconcileTypeForVSClass, oldVSClass, newVSClass := IdentifyReconcileFuncForVSClass(log, vsClassList, nsc)
 
 	log.Debug(fmt.Sprintf("[runEventReconcile] reconcile operation for VolumeSnapshotClass %q: %q", nsc.Name, reconcileTypeForVSClass))
 	switch reconcileTypeForVSClass {

--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -56,6 +56,8 @@ const (
 	NFSStorageClassManagedLabelKey         = "storage.deckhouse.io/managed-by"
 	NFSStorageClassManagedLabelValue       = "nfs-storage-class-controller"
 
+	NFSStorageClassVolumeSnapshotClassAnnotationKey = "storage.deckhouse.io/volumesnapshotclass"
+
 	StorageClassDefaultAnnotationKey     = "storageclass.kubernetes.io/is-default-class"
 	StorageClassDefaultAnnotationValTrue = "true"
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -277,7 +277,7 @@ func RunEventReconcile(ctx context.Context, cl client.Client, log logger.Logger,
 		return true, err
 	}
 
-	reconcileTypeForVSClass, oldVSClass, newVSClass := IdentifyReconcileFuncForVSClass(log, vsClassList, nsc)
+	reconcileTypeForVSClass, oldVSClass, newVSClass := IdentifyReconcileFuncForVSClass(log, vsClassList, nsc, controllerNamespace)
 
 	log.Debug(fmt.Sprintf("[runEventReconcile] reconcile operation for VolumeSnapshotClass %q: %q", nsc.Name, reconcileTypeForVSClass))
 	switch reconcileTypeForVSClass {

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -678,7 +678,6 @@ func configureSecret(nsc *v1alpha1.NFSStorageClass, controllerNamespace string) 
 		},
 		StringData: map[string]string{
 			MountOptionsSecretKey: strings.Join(mountOptions, ","),
-
 		},
 	}
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -772,7 +772,7 @@ func ConfigureVSClass(oldVSClass *snapshotv1.VolumeSnapshotClass, nsc *v1alpha1.
 		Driver:         NFSStorageClassProvisioner,
 		DeletionPolicy: deletionPolicy,
 		Parameters: map[string]string{
-			"mountOptions": strings.Join(GetSCMountOptions(nsc), ","),
+			"mountOptions":                strings.Join(GetSCMountOptions(nsc), ","),
 			SnapshotterSecretNameKey:      SecretForMountOptionsPrefix + nsc.Name,
 			SnapshotterSecretNamespaceKey: controllerNamespace,
 		},

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -689,7 +689,7 @@ func configureSecret(nsc *v1alpha1.NFSStorageClass, controllerNamespace string) 
 }
 
 // VolumeSnaphotClass
-func IdentifyReconcileFuncForVSClass(log logger.Logger, vsClassList *snapshotv1.VolumeSnapshotClassList, nsc *v1alpha1.NFSStorageClass, controllerNamespace string) (reconcileType string, oldVSClass, newVSClass *snapshotv1.VolumeSnapshotClass) {
+func IdentifyReconcileFuncForVSClass(log logger.Logger, vsClassList *snapshotv1.VolumeSnapshotClassList, nsc *v1alpha1.NFSStorageClass) (reconcileType string, oldVSClass, newVSClass *snapshotv1.VolumeSnapshotClass) {
 	oldVSClass = findVSClass(vsClassList, nsc.Name)
 
 	if oldVSClass == nil {

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -775,7 +775,7 @@ func ConfigureVSClass(oldVSClass *snapshotv1.VolumeSnapshotClass, nsc *v1alpha1.
 		Parameters: map[string]string{
 			"mountOptions": strings.Join(GetSCMountOptions(nsc), ","),
 			SnapshotterSecretNameKey:      SecretForMountOptionsPrefix + nsc.Name,
-			SnapshotterSecretNamespaceKey: controllerNamespace,			
+			SnapshotterSecretNamespaceKey: controllerNamespace,
 		},
 	}
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -703,7 +703,7 @@ func IdentifyReconcileFuncForVSClass(log logger.Logger, vsClassList *snapshotv1.
 		return DeleteReconcile, oldVSClass, nil
 	}
 
-	newVSClass = ConfigureVSClass(oldVSClass, nsc, controllerNamespace)
+	newVSClass = ConfigureVSClass(oldVSClass, nsc)
 	log.Debug(fmt.Sprintf("[IdentifyReconcileFuncForVSClass] successfully configurated new volume snapshot class for the NFSStorageClass %s", nsc.Name))
 	log.Trace(fmt.Sprintf("[IdentifyReconcileFuncForVSClass] new volume snapshot class: %+v", newVSClass))
 
@@ -757,9 +757,8 @@ func findVSClass(vsClassList *snapshotv1.VolumeSnapshotClassList, name string) *
 	return nil
 }
 
-func ConfigureVSClass(oldVSClass *snapshotv1.VolumeSnapshotClass, nsc *v1alpha1.NFSStorageClass, controllerNamespace string) *snapshotv1.VolumeSnapshotClass {
+func ConfigureVSClass(oldVSClass *snapshotv1.VolumeSnapshotClass, nsc *v1alpha1.NFSStorageClass) *snapshotv1.VolumeSnapshotClass {
 	deletionPolicy := snapshotv1.DeletionPolicy(nsc.Spec.ReclaimPolicy)
-
 
 	newVSClass := &snapshotv1.VolumeSnapshotClass{
 		ObjectMeta: metav1.ObjectMeta{

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
@@ -174,23 +174,6 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 
 	})
 
-	It("Annotate_sc_as_default_sc", func() {
-		sc := &storagev1.StorageClass{}
-		err := cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sc.Annotations).To(BeNil())
-
-		sc.Annotations = map[string]string{
-			controller.StorageClassDefaultAnnotationKey: controller.StorageClassDefaultAnnotationValTrue,
-		}
-
-		err = cl.Update(ctx, sc)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sc.Annotations).To(HaveLen(1))
-		Expect(sc.Annotations).To(HaveKeyWithValue(controller.StorageClassDefaultAnnotationKey, controller.StorageClassDefaultAnnotationValTrue))
-
-	})
-
 	It("Update_nfs_sc_1", func() {
 		nsc := &v1alpha1.NFSStorageClass{}
 		err := cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, nsc)

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_test.go
@@ -228,7 +228,7 @@ var _ = Describe(controller.NFSStorageClassCtrlName, func() {
 		err := cl.Get(ctx, client.ObjectKey{Name: nameForTestResource}, sc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sc.Annotations).To(HaveLen(1))
-		Expect(sc.Annotations).To(HaveKeyWithValue(controller.StorageClassDefaultAnnotationKey, controller.StorageClassDefaultAnnotationValTrue))
+		Expect(sc.Annotations).To(HaveKeyWithValue(controller.NFSStorageClassVolumeSnapshotClassAnnotationKey, sc.Name))
 
 	})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add VolumeSnapshot mount options to VolumeSnapshotClasses, and  VolumeSnapshotClassName annotations to StorageClasses

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct snapshot work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
