### PR TITLE
[internal] switch service account to csi

### DIFF
--- a/images/wrap-mount/werf.inc.yaml
+++ b/images/wrap-mount/werf.inc.yaml
@@ -35,7 +35,6 @@ secrets:
 
 shell:
   install:
-    - set -x
     - cd /src/images/{{ $.ImageName }}/cmd
     - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
     - |

--- a/templates/csi/controller.yaml
+++ b/templates/csi/controller.yaml
@@ -267,10 +267,10 @@ storage.deckhouse.io/csi-nfs-node: ""
 {{- end }}
 
 {{- $csiNodeConfig := dict }}
-{{- $_ := set $csiNodeConfig "fullname" "csi-nfs" }}
 {{- $_ := set $csiNodeConfig "nodeImage" $csiControllerImage }}
 {{- $_ := set $csiNodeConfig "driverFQDN" "nfs.csi.k8s.io" }}
 {{- $_ := set $csiNodeConfig "livenessProbePort" 4230 }}
+{{- $_ := set $csiNodeConfig "serviceAccount" "csi" }}
 {{- $_ := set $csiNodeConfig "additionalNodeVPA" (include "csi_node_additional_vpa" . | fromYamlArray) }}
 {{- $_ := set $csiNodeConfig "additionalNodeArgs" (include "csi_node_args" . | fromYamlArray) }}
 {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_envs" . | fromYamlArray) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We need to use non default service account in CSI

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct CSI work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
