### PR TITLE
[internal] add sys fs cgroup mount

### DIFF
--- a/templates/csi/controller.yaml
+++ b/templates/csi/controller.yaml
@@ -36,6 +36,8 @@ checksum/ca: {{ .Values.csiNfs.tlsParameters.ca | sha256sum | quote }}
   volumeMounts:
     - name: host-sys
       mountPath: /sys
+    - name: host-sys-fs-cgroup
+      mountPath: /sys/fs/cgroup
     - name: host-lib-modules
       mountPath: /lib/modules
 - name: net-handshake-checker
@@ -61,6 +63,10 @@ checksum/ca: {{ .Values.csiNfs.tlsParameters.ca | sha256sum | quote }}
 - name: host-sys
   hostPath:
     path: /sys
+    type: Directory
+- name: host-sys-fs-cgroup
+  hostPath:
+    path: /sys/fs/cgroup
     type: Directory
 - name: host-lib-modules
   hostPath:


### PR DESCRIPTION
## Description

Add /sys/fs/cgroup mount for containerd v2 support

## What is the expected result?

Containerd v2 support for module

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
