### PR TITLE
[internal] Fix volume mounts for containerdv2 support

### DIFF
--- a/images/csi-nfs/mount-points.yaml
+++ b/images/csi-nfs/mount-points.yaml
@@ -1,3 +1,3 @@
 dirs:
-  - /var/lib/kubelet
+  - /var/lib/kubelet/pods
   - /csi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix volume mounts for containerdv2 support
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
```
message: 'failed to create containerd task: failed to create shim task: OCI
          runtime create failed: runc create failed: unable to start container process:
          error during container init: error mounting "/var/lib/kubelet/pods" to rootfs
          at "/var/lib/kubelet/pods": create mountpoint for /var/lib/kubelet/pods
          mount: mkdirat /run/containerd/io.containerd.runtime.v2.task/k8s.io/5a4c35f4c29df5bc6698056f95a81b80fe06239e080a045aaefc534671e16324/rootfs/var/lib/kubelet/pods:
          read-only file system'
```
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
