### PR TITLE
[bashible] Tolerate package install failures in NodeGroupConfiguration

### DIFF
--- a/templates/nodegroupconfiguration-nfs-common-install-altlinux.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-altlinux.yaml
@@ -33,7 +33,15 @@ spec:
       exit 0
     fi
 
-    apt-get install rpcbind nfs-utils
+    install_packages() {
+      apt-get update && apt-get install -y rpcbind nfs-utils
+    }
+
+    if ! install_packages; then
+      bb-log-error "Failed to install required packages (rpcbind nfs-utils). Skipping further configuration on this node."
+      exit 0
+    fi
+
     systemctl start rpcbind
     systemctl start rpc-statd.service
     systemctl enable rpcbind

--- a/templates/nodegroupconfiguration-nfs-common-install-altlinux.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-altlinux.yaml
@@ -33,9 +33,9 @@ spec:
       exit 0
     fi
 
-    install_packages() {
+    install_packages() (
       apt-get update && apt-get install -y rpcbind nfs-utils
-    }
+    )
 
     if ! install_packages; then
       bb-log-error "Failed to install required packages (rpcbind nfs-utils). Skipping further configuration on this node."

--- a/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
@@ -33,9 +33,9 @@ spec:
       exit 0
     fi
 
-    install_packages() {
+    install_packages() (
       bb-dnf-install "nfs-utils" "rpcbind"
-    }
+    )
 
     if ! install_packages; then
       bb-log-error "Failed to install required packages (nfs-utils rpcbind). Skipping further configuration on this node."

--- a/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-centos.yaml
@@ -33,8 +33,15 @@ spec:
       exit 0
     fi
 
-    bb-dnf-install "nfs-utils" "rpcbind"
-    
+    install_packages() {
+      bb-dnf-install "nfs-utils" "rpcbind"
+    }
+
+    if ! install_packages; then
+      bb-log-error "Failed to install required packages (nfs-utils rpcbind). Skipping further configuration on this node."
+      exit 0
+    fi
+
     # This is dirty hack for statd, because it can't be enabled via systemd in newer distributive (Bashible performs a full cycle at every node reboot, so statd will be started)
     systemctl start rpc-statd.service
 {{- end }}

--- a/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
@@ -33,9 +33,9 @@ spec:
       exit 0
     fi
 
-    install_packages() {
+    install_packages() (
       bb-apt-install "nfs-common" "rpcbind"
-    }
+    )
 
     if ! install_packages; then
       bb-log-error "Failed to install required packages (nfs-common rpcbind). Skipping further configuration on this node."

--- a/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
+++ b/templates/nodegroupconfiguration-nfs-common-install-debian.yaml
@@ -33,8 +33,15 @@ spec:
       exit 0
     fi
 
-    bb-apt-install "nfs-common" "rpcbind"
-    
+    install_packages() {
+      bb-apt-install "nfs-common" "rpcbind"
+    }
+
+    if ! install_packages; then
+      bb-log-error "Failed to install required packages (nfs-common rpcbind). Skipping further configuration on this node."
+      exit 0
+    fi
+
     # This is dirty hack for statd, because it can't be enabled via systemd in newer distributive (Bashible performs a full cycle at every node reboot, so statd will be started)
     systemctl start rpc-statd.service
 {{- end }}


### PR DESCRIPTION
## Description
Wrap package installation commands in `NodeGroupConfiguration` (NGC) bashible scripts so that bashible does not enter a re-run loop when required OS packages cannot be installed (for example, in air-gapped environments where the package repository is unavailable, or when a package is missing).

The pattern applied to each affected NGC template:

- Package install commands (`bb-apt-install` / `bb-dnf-install` / `apt-get install -y`) are wrapped into a shell function (`install_packages` / `install_kernel_headers` / `install_build_packages`).
- The function call is guarded by `if ! install_packages; then bb-log-error "..."; exit 0; fi`.
- For Altlinux `apt-get`, `apt-get update` is now chained via `&&` with `apt-get install -y` so update failures are caught too.
- Subsequent non-installation operations that may fail (`enable_services`, `configure_multipath`, etc.) use `|| bb-log-error "..."` instead of `|| echo "..."`.

## Why do we need it, and what problem does it solve?
Bash Booster's `bb-*-install` functions and `apt-get install` under `set -Eeo pipefail` exit with non-zero status if any package cannot be installed. As a result:

- The bashible step exits with non-zero code.
- The `node.deckhouse.io/configuration-checksum` label is not updated on the node.
- Bashible re-runs the same failing step on every tick, flooding `journalctl -u bashible.service` and blocking other node configuration.
- The node remains stuck even though the failure is non-recoverable from the script's side (e.g., package simply absent in the repo).

After this change, package install failures are clearly logged via `bb-log-error` and the script exits with `0`, so:

- The configuration checksum is updated.
- Bashible stops looping on this step.
- The error is visible in bashible logs and node events for the operator to act on.

## What is the expected result?
- On a node where required packages are available — behavior is unchanged; packages are installed and the rest of the NGC script runs as before.
- On a node where required packages are missing in the repository:
  - The bashible step finishes successfully (exit code `0`).
  - `bb-log-error "Failed to install required packages (...). Skipping further configuration on this node."` is present in the bashible step log.
  - The `node.deckhouse.io/configuration-checksum` label is updated.
  - The bashible step is no longer retried in a loop on the same checksum.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
