### PR TITLE
[crd] Add nolock mount option for NFSv3 NFSStorageClass

### DIFF
--- a/api/v1alpha1/nfs_storage_class.go
+++ b/api/v1alpha1/nfs_storage_class.go
@@ -63,6 +63,8 @@ type NFSStorageClassMountOptions struct {
 	Timeout         int    `json:"timeout,omitempty"`
 	Retransmissions int    `json:"retransmissions,omitempty"`
 	ReadOnly        *bool  `json:"readOnly,omitempty"`
+	// Nolock disables NLM file locking; only valid for NFSv3.
+	Nolock *bool `json:"nolock,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -114,6 +114,11 @@ func (in *NFSStorageClassMountOptions) DeepCopyInto(out *NFSStorageClassMountOpt
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Nolock != nil {
+		in, out := &in.Nolock, &out.Nolock
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/crds/nfsstorageclass.yaml
+++ b/crds/nfsstorageclass.yaml
@@ -37,6 +37,8 @@ spec:
                   message: "If reclaimPolicy is 'Retain', volumeCleanup must be omitted."
                 - rule: "self.connection.nfsVersion == '4.2' || !has(self.volumeCleanup)|| self.volumeCleanup != 'Discard'"
                   message: "Discard mode is only available when connection.nfsVersion is '4.2'."
+                - rule: "!has(self.mountOptions) || !has(self.mountOptions.nolock) || !self.mountOptions.nolock || self.connection.nfsVersion == '3'"
+                  message: "mountOptions.nolock can be enabled only when connection.nfsVersion is '3'."
               description: |
                 Defines a Kubernetes StorageClass configuration.
               required:
@@ -131,6 +133,15 @@ spec:
                       type: boolean
                       description: |
                         Share read-only flag.
+                    nolock:
+                      type: boolean
+                      description: |
+                        Disables NLM file locking on the client (mount option `nolock`).
+                        Only applicable to NFSv3 mounts; for NFSv4.x locking is part of the protocol
+                        and this option must not be set.
+                        Useful when the NFS server does not run rpc.statd / rpc.lockd or when
+                        cross-host file locking is not required.
+                      default: false
                 chmodPermissions:
                   type: string
                   description: |

--- a/images/controller/pkg/controller/nfs_storage_class_mount_options_test.go
+++ b/images/controller/pkg/controller/nfs_storage_class_mount_options_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1alpha1 "github.com/deckhouse/csi-nfs/api/v1alpha1"
+	"github.com/deckhouse/csi-nfs/images/controller/pkg/controller"
+)
+
+var _ = Describe("GetSCMountOptions", func() {
+	boolPtr := func(b bool) *bool { return &b }
+
+	It("emits nolock for NFSv3 when MountOptions.Nolock is true", func() {
+		nsc := &v1alpha1.NFSStorageClass{
+			Spec: v1alpha1.NFSStorageClassSpec{
+				Connection: &v1alpha1.NFSStorageClassConnection{
+					Host:       "10.0.0.1",
+					Share:      "/data",
+					NFSVersion: "3",
+				},
+				MountOptions: &v1alpha1.NFSStorageClassMountOptions{
+					Nolock: boolPtr(true),
+				},
+			},
+		}
+
+		Expect(controller.GetSCMountOptions(nsc)).To(ContainElement("nolock"))
+	})
+
+	It("does not emit nolock when MountOptions.Nolock is false", func() {
+		nsc := &v1alpha1.NFSStorageClass{
+			Spec: v1alpha1.NFSStorageClassSpec{
+				Connection: &v1alpha1.NFSStorageClassConnection{
+					Host:       "10.0.0.1",
+					Share:      "/data",
+					NFSVersion: "3",
+				},
+				MountOptions: &v1alpha1.NFSStorageClassMountOptions{
+					Nolock: boolPtr(false),
+				},
+			},
+		}
+
+		Expect(controller.GetSCMountOptions(nsc)).NotTo(ContainElement("nolock"))
+	})
+
+	It("does not emit nolock when MountOptions.Nolock is unset", func() {
+		nsc := &v1alpha1.NFSStorageClass{
+			Spec: v1alpha1.NFSStorageClassSpec{
+				Connection: &v1alpha1.NFSStorageClassConnection{
+					Host:       "10.0.0.1",
+					Share:      "/data",
+					NFSVersion: "3",
+				},
+				MountOptions: &v1alpha1.NFSStorageClassMountOptions{},
+			},
+		}
+
+		Expect(controller.GetSCMountOptions(nsc)).NotTo(ContainElement("nolock"))
+	})
+
+	DescribeTable("does not emit nolock for non-v3 versions even if Nolock=true (defence-in-depth, CRD CEL also blocks this)",
+		func(version string) {
+			nsc := &v1alpha1.NFSStorageClass{
+				Spec: v1alpha1.NFSStorageClassSpec{
+					Connection: &v1alpha1.NFSStorageClassConnection{
+						Host:       "10.0.0.1",
+						Share:      "/data",
+						NFSVersion: version,
+					},
+					MountOptions: &v1alpha1.NFSStorageClassMountOptions{
+						Nolock: boolPtr(true),
+					},
+				},
+			}
+
+			Expect(controller.GetSCMountOptions(nsc)).NotTo(ContainElement("nolock"))
+		},
+		Entry("NFSv4.1", "4.1"),
+		Entry("NFSv4.2", "4.2"),
+	)
+})

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -572,6 +572,16 @@ func GetSCMountOptions(nsc *v1alpha1.NFSStorageClass) []string {
 				mountOptions = append(mountOptions, "rw")
 			}
 		}
+
+		// nolock is only valid for NFSv3; for NFSv4.x file locking is part of the
+		// protocol itself and adding `nolock` would be silently ignored or rejected.
+		// CRD-level CEL validation prevents setting nolock=true with nfsVersion!=3,
+		// but we double-check here so accidental misconfigurations never leak into
+		// the StorageClass mount options.
+		if nsc.Spec.MountOptions.Nolock != nil && *nsc.Spec.MountOptions.Nolock &&
+			nsc.Spec.Connection != nil && nsc.Spec.Connection.NFSVersion == "3" {
+			mountOptions = append(mountOptions, "nolock")
+		}
 	}
 
 	return mountOptions

--- a/lib/go/common/pkg/validating/validator.go
+++ b/lib/go/common/pkg/validating/validator.go
@@ -41,6 +41,16 @@ func ValidateNFSStorageClass(nfsModuleConfig *d8commonapi.ModuleConfig, nsc *cn.
 		}
 	}
 
+	if nsc.Spec.MountOptions != nil &&
+		nsc.Spec.MountOptions.Nolock != nil && *nsc.Spec.MountOptions.Nolock &&
+		nsc.Spec.Connection.NFSVersion != "3" {
+		return fmt.Errorf(
+			"NFSStorageClass: %s (mountOptions.nolock is set to true, but nfsVersion is %q); "+
+				"the nolock mount option is only applicable to NFSv3; %s",
+			nsc.Name, nsc.Spec.Connection.NFSVersion, logPostfix,
+		)
+	}
+
 	if feature.TLSEnabled() {
 		if nsc.Spec.Connection.Tls || nsc.Spec.Connection.Mtls {
 			var tlsParameters map[string]any


### PR DESCRIPTION
## Description

Adds a new boolean field `spec.mountOptions.nolock` to the `NFSStorageClass`
custom resource. When set to `true`, the controller appends `nolock` to the
mount options of the managed `StorageClass` (and the corresponding
`nfs-mount-options-for-<name>` Secret).

The `nolock` mount option disables client-side NLM file locking and is only
meaningful for NFSv3. For NFSv4.x byte-range locking is part of the protocol
itself, so passing `nolock` there is meaningless and is rejected by the API.

The constraint is enforced in three layers:

1. **CRD CEL validation** (the place explicitly requested in the issue) — a
   new `x-kubernetes-validations` rule on `spec` rejects creating/updating an
   `NFSStorageClass` with `mountOptions.nolock: true` unless
   `connection.nfsVersion` is `"3"`:

   ```yaml
   - rule: "!has(self.mountOptions) || !has(self.mountOptions.nolock) || !self.mountOptions.nolock || self.connection.nfsVersion == '3'"
     message: "mountOptions.nolock can be enabled only when connection.nfsVersion is '3'."
   ```

2. **Admission webhook** (`lib/go/common/pkg/validating/validator.go`) — same
   check, mirrors the existing pattern used for `tls`/`mtls`/`v3support`.

3. **Controller defence-in-depth** (`GetSCMountOptions`) — even if a malformed
   object somehow reaches the reconciler, `nolock` is only emitted when
   `nfsVersion == "3"`.

## Why do we need it, and what problem does it solve?

NFSv3 is intentionally available in this module (gated by
`csi-nfs.spec.settings.v3support`). A common deployment scenario is mounting
shares against an NFS server that does not run `rpc.statd`/`rpc.lockd` (or
where cross-host file locking is not desired), in which case the client must
mount with `nolock` — otherwise mount or first-write operations hang or fail
with `lockd not running` style errors.

Today there is no way to set `nolock` through `NFSStorageClass`: the schema
exposes only `mountMode`, `timeout`, `retransmissions`, `readOnly`, and the
controller assembles `mountOptions` from exactly that fixed set
(`images/controller/pkg/controller/nfs_storage_class_watcher_func.go::GetSCMountOptions`).
Users had to drop down to a hand-written `StorageClass` and replicate the
Secret/parameters that the controller would normally manage.

## What is the expected result?

- `kubectl apply` of an `NFSStorageClass` with `mountOptions.nolock: true` and
  `connection.nfsVersion: "3"` succeeds; the resulting `StorageClass.MountOptions`
  contains `nolock` (in addition to `nfsvers=3` and any other configured options),
  and the same string is present in the `nfs-mount-options-for-<name>` Secret.
- `kubectl apply` of the same with `nfsVersion: "4.1"` or `"4.2"` is rejected
  by the apiserver with the message
  `mountOptions.nolock can be enabled only when connection.nfsVersion is '3'.`
- Existing `NFSStorageClass` objects (without `nolock`) are unaffected — the
  field is optional and defaults to `false`.

## Implementation notes

- `NFSStorageClassMountOptions.Nolock` is `*bool` to mirror the existing
  `ReadOnly` field and to keep the JSON serialization compatible
  (`omitempty` on absence).
- `zz_generated.deepcopy.go` is updated by hand to match the deepcopy-gen
  output for the new pointer field; running `deepcopy-gen` would produce the
  same diff.
- No CHANGELOG entry is added in this PR — the repository convention is to
  collect changelog entries in dedicated `changelog: vX.Y.Z release` PRs
  (see #182, #176, #174). Happy to add one if maintainers prefer per-feature
  changelogs.

## Checklist

- [x] The code is covered by unit tests
  (`images/controller/pkg/controller/nfs_storage_class_mount_options_test.go`,
  5 new specs covering v3/non-v3 and unset/false/true).
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes — the CRD field
  description is the canonical reference (rendered into `docs/`); no
  doc page enumerates `mountOptions` today.
- [ ] Changes were tested in the Kubernetes cluster manually.