### PR TITLE
Sync base-images v0.5.73, Go 1.25.9, lib-helm 1.71.9

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.69"
+  BASE_IMAGES_VERSION: "v0.5.73"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.69"
+  BASE_IMAGES_VERSION: "v0.5.73"
 on:
   push:
     tags:

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,7 +1,6 @@
 module github.com/deckhouse/csi-nfs/api
 
-go 1.25.7
-
+go 1.25.9
 require k8s.io/apimachinery v0.32.0
 
 require (


### PR DESCRIPTION
## Description
Automated tooling sync for **csi-nfs** (scheduled `sync_storage_modules_tooling.py`).

- **BASE_IMAGES_VERSION**: `v0.5.69` → `v0.5.73` in `.github/workflows/*.yml`.
- **Go**: set `go 1.25.9` in **1** `go.mod` file(s) under `api/`, `images/` and `hooks/` (aligned with `builder/golang-bookworm` from `base_images.yml`).
- **lib-helm**: already **1.71.9**; chart bundle in `charts/` unchanged.

## Why do we need it, and what problem does it solve?
Keeps the module aligned with the latest **deckhouse/base-images** release and **deckhouse/lib-helm**
so CI and image builds use current base image digests, Go toolchain version, and Helm library charts.

## What is the expected result?
- Pipelines resolve `BASE_IMAGES_VERSION` to the new (or current) tag and download matching `base_images.yml`.
- Go code under `api/`, `images/` and `hooks/` declares the same Go version as the default `builder/golang-bookworm` image.
- `charts/` contains the current `deckhouse_lib_helm-*.tgz` when an update was required.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
