### PR TITLE
Sync base-images v0.5.74, Go 1.25.10, lib-helm 1.71.9

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.73"
+  BASE_IMAGES_VERSION: "v0.5.74"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.73"
+  BASE_IMAGES_VERSION: "v0.5.74"
 on:
   push:
     tags:

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/csi-nfs/api
 
-go 1.25.9
+go 1.25.10
 require k8s.io/apimachinery v0.32.0
 
 require (

--- a/hooks/go/go.mod
+++ b/hooks/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/csi-nfs/hooks/go
 
-go 1.25.9
+go 1.25.10
 require (
 	github.com/deckhouse/csi-nfs/api v0.0.0-20250314071217-91b1f5b52e17
 	github.com/deckhouse/module-sdk v0.7.0

--- a/images/controller/go.mod
+++ b/images/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/csi-nfs/images/controller
 
-go 1.25.9
+go 1.25.10
 require (
 	github.com/deckhouse/csi-nfs/api v0.0.0-20250213115525-4785a9da80db
 	github.com/deckhouse/csi-nfs/lib/go/common v0.0.0-20250213115525-4785a9da80db

--- a/images/csi-nfs-scheduler-extender/go.mod
+++ b/images/csi-nfs-scheduler-extender/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/csi-nfs/images/csi-nfs-scheduler-extender
 
-go 1.25.9
+go 1.25.10
 require (
 	github.com/deckhouse/csi-nfs/api v0.0.0-20250213115525-4785a9da80db
 	github.com/go-logr/logr v1.4.2

--- a/images/tlshd/go.mod
+++ b/images/tlshd/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/csi-nfs/images/tlshd
 
-go 1.25.9
+go 1.25.10
 require github.com/spf13/cobra v1.8.1
 
 require (

--- a/images/wait-rpcbind/go.mod
+++ b/images/wait-rpcbind/go.mod
@@ -1,3 +1,3 @@
 module github.com/deckhouse/csi-nfs/images/wait-rpcbind
 
-go 1.25.9
+go 1.25.10

--- a/images/webhooks/go.mod
+++ b/images/webhooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/csi-nfs/images/webhooks
 
-go 1.25.9
+go 1.25.10
 require (
 	github.com/deckhouse/csi-nfs/api v0.0.0-20250213115525-4785a9da80db
 	github.com/deckhouse/csi-nfs/lib/go/common v0.0.0-20250213115525-4785a9da80db

--- a/images/wrap-mount/go.mod
+++ b/images/wrap-mount/go.mod
@@ -1,3 +1,3 @@
 module github.com/deckhouse/csi-nfs/images/wrap-mount
 
-go 1.25.9
+go 1.25.10


### PR DESCRIPTION
## Description
Automated tooling sync for **csi-nfs** (scheduled `sync_storage_modules_tooling.py`).

- **BASE_IMAGES_VERSION**: `v0.5.73` → `v0.5.74` in `.github/workflows/*.yml`.
- **Go**: set `go 1.25.10` in **8** `go.mod` file(s) under `api/`, `images/` and `hooks/` (aligned with `builder/golang-bookworm` from `base_images.yml`).
- **lib-helm**: already **1.71.9**; chart bundle in `charts/` unchanged.

## Why do we need it, and what problem does it solve?
Keeps the module aligned with the latest **deckhouse/base-images** release and **deckhouse/lib-helm**
so CI and image builds use current base image digests, Go toolchain version, and Helm library charts.

## What is the expected result?
- Pipelines resolve `BASE_IMAGES_VERSION` to the new (or current) tag and download matching `base_images.yml`.
- Go code under `api/`, `images/` and `hooks/` declares the same Go version as the default `builder/golang-bookworm` image.
- `charts/` contains the current `deckhouse_lib_helm-*.tgz` when an update was required.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
