### PR TITLE
fix(build): set GOPROXY for go mod download in wrap-mount

### DIFF
--- a/images/wrap-mount/werf.inc.yaml
+++ b/images/wrap-mount/werf.inc.yaml
@@ -36,6 +36,7 @@ secrets:
 shell:
   install:
     - cd /src/images/{{ $.ImageName }}/cmd
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
     - |
       {{- include "image-build.build" (set $ "BuildCommand" (printf `go build -ldflags="-s -w" -tags %s -o /%s` $.MODULE_EDITION $.ImageName)) | nindent 6 }}


### PR DESCRIPTION
## Description

Bring `wrap-mount` build in line with the other images in this module (controller, csi-nfs, csi-nfs-scheduler-extender, tlshd, wait-rpcbind, webhooks) by adding `GOPROXY=$(cat /run/secrets/GOPROXY) go mod download` before `go build` so that dependencies are pulled through our proxy instead of the default `proxy.golang.org`.

Files changed:
- `images/wrap-mount/werf.inc.yaml` — add `GOPROXY=$(cat /run/secrets/GOPROXY) go mod download` before `go build` (was missing entirely).

## Why do we need it, and what problem does it solve?

The `secrets: - id: GOPROXY` block is already declared in this file but the proxy was never actually used in the build. As a result the build would either fail in environments without access to `proxy.golang.org`, or silently fetch dependencies bypassing the configured corporate proxy. This change unifies the build pattern with the other images in this module.

## What is the expected result?

- Image build for `wrap-mount` succeeds in environments that only have access to the configured `GOPROXY`.
- All Go dependencies for this image are fetched through the same proxy as the rest of the module.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.