### PR TITLE
fix(images): mount-points for csi-nfs-scheduler-extender distroless image

### DIFF
--- a/images/csi-nfs-scheduler-extender/mount-points.yaml
+++ b/images/csi-nfs-scheduler-extender/mount-points.yaml
@@ -1,0 +1,3 @@
+dirs:
+  - /etc/csi-nfs-scheduler-extender
+  - /etc/csi-nfs-scheduler-extender/certs

--- a/images/csi-nfs-scheduler-extender/werf.inc.yaml
+++ b/images/csi-nfs-scheduler-extender/werf.inc.yaml
@@ -47,6 +47,8 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: base/distroless
+git:
+{{- include "image mount points" . }}
 
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact


### PR DESCRIPTION
## Description

Added `images/csi-nfs-scheduler-extender/mount-points.yaml` with directories required at runtime (`/etc/csi-nfs-scheduler-extender` and `/etc/csi-nfs-scheduler-extender/certs`). The final distroless image stage now includes `{{- include "image mount points" . }}`, consistent with other CSI NFS images (`controller`, `webhooks`, etc.).

This change does not restart cluster-wide components beyond the CSI NFS scheduler extender Deployment when the module is upgraded.

## Why do we need it, and what problem does it solve?

The scheduler extender image is built from `base/distroless` with a read-only root filesystem. Helm mounts the ConfigMap and TLS Secret under `/etc/csi-nfs-scheduler-extender`. Without placeholder directories produced from `mount-points.yaml`, the image build omits those paths and volume mounts may fail or behave incorrectly compared to other images that already declare mount points.

## What is the expected result?

- Werf renders the final image with git mounts derived from `mount-points.yaml` for image name `csi-nfs-scheduler-extender`.
- Pods can mount `scheduler-extender-config` and `scheduler-extender-certs` at the configured paths.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
