### PR TITLE
Propagate StorageClass labels from NFSStorageClass CR

### DIFF
--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -174,8 +174,10 @@ func RunNFSStorageClassWatcherController(
 		UpdateFunc: func(_ context.Context, e event.TypedUpdateEvent[*v1alpha1.NFSStorageClass], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			log.Info(fmt.Sprintf("[UpdateFunc] get event for NFSStorageClass %q. Check if it should be reconciled", e.ObjectNew.GetName()))
 
-			if reflect.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec) && e.ObjectNew.DeletionTimestamp == nil {
-				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the NFSStorageClass %s has no Spec field updates. It will not be reconciled", e.ObjectNew.Name))
+			if reflect.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec) &&
+				reflect.DeepEqual(e.ObjectOld.Labels, e.ObjectNew.Labels) &&
+				e.ObjectNew.DeletionTimestamp == nil {
+				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the NFSStorageClass %s has no Spec or Labels updates. It will not be reconciled", e.ObjectNew.Name))
 				return
 			}
 

--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -459,9 +459,6 @@ func ConfigureStorageClass(oldSC *storagev1.StorageClass, nsc *v1alpha1.NFSStora
 			Annotations: map[string]string{
 				NFSStorageClassVolumeSnapshotClassAnnotationKey: nsc.Name,
 			},
-			Labels: map[string]string{
-				NFSStorageClassManagedLabelKey: NFSStorageClassManagedLabelValue,
-			},
 			Finalizers: []string{NFSStorageClassControllerFinalizerName},
 		},
 		Parameters:           GetSCParams(nsc, controllerNamespace),
@@ -472,12 +469,16 @@ func ConfigureStorageClass(oldSC *storagev1.StorageClass, nsc *v1alpha1.NFSStora
 		AllowVolumeExpansion: &AllowVolumeExpansion,
 	}
 
-	if oldSC != nil {
-		if oldSC.Labels != nil {
-			newSc.Labels = labels.Merge(oldSC.Labels, newSc.Labels)
-		}
-		if oldSC.Annotations != nil {
-			newSc.Annotations = labels.Merge(oldSC.Annotations, newSc.Annotations)
+	if oldSC != nil && oldSC.Annotations != nil {
+		newSc.Annotations = labels.Merge(oldSC.Annotations, newSc.Annotations)
+	}
+
+	if nsc.Labels != nil {
+		newSc.Labels = nsc.Labels
+		newSc.Labels[NFSStorageClassManagedLabelKey] = NFSStorageClassManagedLabelValue
+	} else {
+		newSc.Labels = map[string]string{
+			NFSStorageClassManagedLabelKey: NFSStorageClassManagedLabelValue,
 		}
 	}
 


### PR DESCRIPTION
## Description
Propagate `metadata.labels` from `NFSStorageClass` CR to the native Kubernetes `StorageClass`, following the same pattern as csi-ceph.

## Why do we need it, and what problem does it solve?
Users need to attach custom labels to StorageClasses (for monitoring, policy, or inventory). The csi-nfs controller manages StorageClasses via Deckhouse CRs; without label propagation, labels set on the CR were not reflected on the actual StorageClass resource.

## What is the expected result?
After creating or updating a `NFSStorageClass` with `metadata.labels`, the corresponding `StorageClass` has those labels plus `storage.deckhouse.io/managed-by`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.