### PR TITLE
fix(ci): use PROD registry credentials in prod build step

### DIFF
--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -58,8 +58,8 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
-          registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
 
@@ -103,8 +103,8 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
-          registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
 
@@ -148,8 +148,8 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
-          registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
 
@@ -193,8 +193,8 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
-          registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
 
@@ -238,7 +238,7 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
-          registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}


### PR DESCRIPTION
## Description

The prod build steps in `.github/workflows/build_prod.yml` push module images to the **PROD** registry — `module_source` is `${{ vars.PROD_REGISTRY }}/…` — but pass **DEV** registry credentials to `deckhouse/modules-actions/build@v15`:

```yaml
registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
```

`modules-actions/build` uses `registry_user` / `registry_password` to authenticate to `module_source` (the primary `werf build --repo` target), so the credentials must match the PROD registry.

This changes them to the PROD credentials in all editions (ce/ee/fe/se/se-plus):

```yaml
registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
```

The secondary DEV registry `setup` login step is intentionally left unchanged — it correctly logs into the DEV registry with DEV credentials.

## Why do we need it, and what problem does it solve?

The mismatch was introduced in #210 (VEX attestation), which added `registry_user`/`registry_password` to the build step using DEV values. With DEV credentials the build authenticates to the PROD registry incorrectly, causing authentication failures when pushing prod images on tag builds. This restores the correct behaviour and matches the pattern used by the other storage modules (csi-ceph, sds-*, snapshot-controller, state-snapshotter, storage-foundation).

## What is the expected result?

A tagged prod build (`build_prod.yml`) authenticates to the PROD registry with the PROD credentials and successfully builds and pushes the module images for every edition.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
