### PR TITLE
fix(tlshd): point wrapper at the pm ktls-utils install paths

### DIFF
--- a/images/tlshd/cmd/main.go
+++ b/images/tlshd/cmd/main.go
@@ -95,10 +95,10 @@ func main() {
 
 	log.Printf("Launch in %s mode", opt.Mode)
 
-	path := "/opt/deckhouse/csi/bin/tlshd"
+	path := "/usr/bin/tlshd"
 	args := []string{"-s"}
 	if opt.Mode == "init-containers" {
-		args = append(args, "-c", "/opt/deckhouse/csi/etc/tlshd.conf")
+		args = append(args, "-c", "/etc/tlshd.conf")
 	} else {
 		args = append(args, "-c", "/etc/tlshd.conf")
 

--- a/images/tlshd/werf.inc.yaml
+++ b/images/tlshd/werf.inc.yaml
@@ -1,6 +1,6 @@
 {{- /*
 tlshd distroless image. The Go wrapper launches the upstream tlshd daemon
-from the container-base ktls-utils package (opt/deckhouse/csi/bin/tlshd).
+from the container-base ktls-utils package (/usr/bin/tlshd).
 */ -}}
 ---
 # do not remove this image: used in external audits (DKP CSE)


### PR DESCRIPTION
## Description

The `tlshd` Go wrapper exec'd a hardcoded binary path `/opt/deckhouse/csi/bin/tlshd` and, in `init-containers` mode, read `/opt/deckhouse/csi/etc/tlshd.conf`. Neither path exists in the distroless `tlshd` image: the container-base `ktls-utils` pm package installs the daemon to `/usr/bin/tlshd` and its default config to `/etc/tlshd.conf`.

This PR points the wrapper at the actual install paths:
- binary: `/opt/deckhouse/csi/bin/tlshd` → `/usr/bin/tlshd`
- `init-containers` config: `/opt/deckhouse/csi/etc/tlshd.conf` → `/etc/tlshd.conf`

The `containers` (sidecar) mode already used `/etc/tlshd.conf`, where the `tlshd-conf` ConfigMap is subPath-mounted, and is unchanged. The `net-handshake-checker` init container mounts no ConfigMap, so it now reads the package-provided default `/etc/tlshd.conf`. The stale path in the `werf.inc.yaml` header comment is updated to match.

No critical cluster components are affected; the change is confined to the `tlshd` image used by the csi-nfs node/controller pods when NFS-over-TLS is enabled.

## Why do we need it, and what problem does it solve?

With `featureTLSEnabled` and `tlsParameters.ca` set, the `net-handshake-checker` init container crash-loops and blocks the csi-node/controller pods from starting:

```
Launch in init-containers mode
Failed to start the command: fork/exec /opt/deckhouse/csi/bin/tlshd: no such file or directory
```

The daemon binary is simply not at the path the wrapper tried to exec, so kernel-TLS handshake support can never come up. This fixes that regression.

## What is the expected result?

With TLS enabled, the `net-handshake-checker` init container completes successfully (or exits `1` only when the kernel handshake service is genuinely unavailable), and the `tlshd` sidecar starts and stays running. No more `no such file or directory` on `/opt/deckhouse/csi/bin/tlshd`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
