### PR TITLE
feat: make the snapshot-controller dependency optional

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ Before using the module, make sure the following requirements are met:
   - For DKP modules where StorageClass is used, it may be necessary to allow access to clients with root privileges. In Linux, this is implemented via the `no_root_squash` option. On other operating systems and storage systems, a similar setting may have a different name;
   - For virtual disk storage in the [Deckhouse Virtualization Platform](/products/virtualization-platform/documentation/), the `no_root_squash` option is mandatory.
 - To support RPC-with-TLS, enable `CONFIG_TLS` and `CONFIG_NET_HANDSHAKE` options in the Linux kernel.
-- The [`snapshot-controller`](/modules/snapshot-controller/) module must be enabled for this module to operate.
+- Volume snapshots require a module that provides the `snapshot.storage.k8s.io` CRDs, for example [`snapshot-controller`](/modules/snapshot-controller/). Without it, the rest of the module keeps working and no VolumeSnapshotClass is created.
 
 ### Recommendations
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -31,7 +31,7 @@ StorageClass для CSI-драйвера `nfs.csi.k8s.io` создаются т�
   - Для модулей DKP, в настройках которых используется StorageClass, может потребоваться разрешить доступ клиентам с root-правами. В Linux это реализуется через опцию `no_root_squash`. В других операционных системах и СХД аналогичная настройка может иметь иное название;
   - Для хранилища виртуальных дисков в [Deckhouse Virtualization Platform](/products/virtualization-platform/documentation/) опция `no_root_squash` обязательна.
 - Для поддержки RPC-with-TLS включите в ядре Linux опции `CONFIG_TLS` и `CONFIG_NET_HANDSHAKE`.
-- Для работы модуля должен быть включён модуль [`snapshot-controller`](/modules/snapshot-controller/).
+- Для снимков томов требуется модуль, поставляющий CRD группы `snapshot.storage.k8s.io`, — например [`snapshot-controller`](/modules/snapshot-controller/). Без него остальная функциональность модуля работает штатно, а VolumeSnapshotClass не создаётся.
 
 ### Рекомендации
 

--- a/images/controller/pkg/controller/controller_suite_test.go
+++ b/images/controller/pkg/controller/controller_suite_test.go
@@ -28,7 +28,9 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	sv1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -61,8 +63,21 @@ func NewFakeClient() client.Client {
 	}
 
 	// See https://github.com/kubernetes-sigs/controller-runtime/issues/2362#issuecomment-1837270195
-	builder := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1alpha1.NFSStorageClass{})
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.NFSStorageClass{}).
+		WithRESTMapper(snapshotRESTMapper())
 
 	cl := builder.Build()
 	return cl
+}
+
+// snapshotRESTMapper makes the fake client report the VolumeSnapshotClass CRD as
+// registered. The controller gates VolumeSnapshotClass reconciliation on that lookup,
+// and the fake client would otherwise default to an empty mapper, which reads as
+// "the snapshot CRDs are not installed".
+func snapshotRESTMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{snapshotv1.SchemeGroupVersion})
+	mapper.Add(snapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotClass"), meta.RESTScopeRoot)
+	return mapper
 }

--- a/images/controller/pkg/controller/nfs_storage_class_watcher.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher.go
@@ -268,36 +268,40 @@ func RunEventReconcile(ctx context.Context, cl client.Client, log logger.Logger,
 		return shouldRequeue, err
 	}
 
-	vsClassList := &snapshotv1.VolumeSnapshotClassList{}
-	err = cl.List(ctx, vsClassList)
-	if err != nil {
-		err = fmt.Errorf("[runEventReconcile] unable to list VolumeSnapshotClasses: %w", err)
-		upError := updateNFSStorageClassPhase(ctx, cl, nsc, FailedStatusPhase, err.Error())
-		if upError != nil {
-			upError = fmt.Errorf("[reconcileStorageClassCreateFunc] unable to update the NFSStorageClass %s: %w", nsc.Name, upError)
-			err = errors.Join(err, upError)
+	if !VolumeSnapshotClassCRDExists(cl.RESTMapper(), log) {
+		log.Debug(fmt.Sprintf("[runEventReconcile] the VolumeSnapshotClass CRD is not registered in the cluster, skipping the VolumeSnapshotClass for the NFSStorageClass %q", nsc.Name))
+	} else {
+		vsClassList := &snapshotv1.VolumeSnapshotClassList{}
+		err = cl.List(ctx, vsClassList)
+		if err != nil {
+			err = fmt.Errorf("[runEventReconcile] unable to list VolumeSnapshotClasses: %w", err)
+			upError := updateNFSStorageClassPhase(ctx, cl, nsc, FailedStatusPhase, err.Error())
+			if upError != nil {
+				upError = fmt.Errorf("[reconcileStorageClassCreateFunc] unable to update the NFSStorageClass %s: %w", nsc.Name, upError)
+				err = errors.Join(err, upError)
+			}
+			return true, err
 		}
-		return true, err
-	}
 
-	reconcileTypeForVSClass, oldVSClass, newVSClass := IdentifyReconcileFuncForVSClass(log, vsClassList, nsc, controllerNamespace)
+		reconcileTypeForVSClass, oldVSClass, newVSClass := IdentifyReconcileFuncForVSClass(log, vsClassList, nsc, controllerNamespace)
 
-	log.Debug(fmt.Sprintf("[runEventReconcile] reconcile operation for VolumeSnapshotClass %q: %q", nsc.Name, reconcileTypeForVSClass))
-	switch reconcileTypeForVSClass {
-	case CreateReconcile:
-		shouldRequeue, err = reconcileVolumeSnapshotClassCreateFunc(ctx, cl, log, newVSClass, nsc)
-	case UpdateReconcile:
-		shouldRequeue, err = reconcileVolumeSnapshotClassUpdateFunc(ctx, cl, log, oldVSClass, newVSClass, nsc)
-	case DeleteReconcile:
-		shouldRequeue, err = reconcileVolumeSnapshotClassDeleteFunc(ctx, cl, log, oldVSClass, nsc)
-	default:
-		log.Debug(fmt.Sprintf("[runEventReconcile] VolumeSnapshotClass %q should not be reconciled", nsc.Name))
-	}
+		log.Debug(fmt.Sprintf("[runEventReconcile] reconcile operation for VolumeSnapshotClass %q: %q", nsc.Name, reconcileTypeForVSClass))
+		switch reconcileTypeForVSClass {
+		case CreateReconcile:
+			shouldRequeue, err = reconcileVolumeSnapshotClassCreateFunc(ctx, cl, log, newVSClass, nsc)
+		case UpdateReconcile:
+			shouldRequeue, err = reconcileVolumeSnapshotClassUpdateFunc(ctx, cl, log, oldVSClass, newVSClass, nsc)
+		case DeleteReconcile:
+			shouldRequeue, err = reconcileVolumeSnapshotClassDeleteFunc(ctx, cl, log, oldVSClass, nsc)
+		default:
+			log.Debug(fmt.Sprintf("[runEventReconcile] VolumeSnapshotClass %q should not be reconciled", nsc.Name))
+		}
 
-	log.Debug(fmt.Sprintf("[runEventReconcile] ends reconciliataion of VolumeSnapshotClass, name: %s, shouldRequeue: %t, err: %v", nsc.Name, shouldRequeue, err))
+		log.Debug(fmt.Sprintf("[runEventReconcile] ends reconciliataion of VolumeSnapshotClass, name: %s, shouldRequeue: %t, err: %v", nsc.Name, shouldRequeue, err))
 
-	if err != nil || shouldRequeue {
-		return shouldRequeue, err
+		if err != nil || shouldRequeue {
+			return shouldRequeue, err
+		}
 	}
 
 	if nsc.DeletionTimestamp == nil {

--- a/images/controller/pkg/controller/snapshot_crd.go
+++ b/images/controller/pkg/controller/snapshot_crd.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/deckhouse/csi-nfs/images/controller/pkg/logger"
+)
+
+var volumeSnapshotClassGK = schema.GroupKind{Group: snapshotv1.GroupName, Kind: "VolumeSnapshotClass"}
+
+// VolumeSnapshotClassCRDExists reports whether the VolumeSnapshotClass CRD is registered
+// in the cluster. The snapshot CRDs are not shipped by this module and the module no
+// longer requires the module that does ship them, so they may legitimately be absent and
+// every VolumeSnapshotClass operation has to be skipped in that case.
+//
+// The manager's RESTMapper is dynamic and reloads discovery on a miss, so the CRD is
+// picked up without a controller restart once it is installed in the cluster.
+func VolumeSnapshotClassCRDExists(mapper meta.RESTMapper, log logger.Logger) bool {
+	_, err := mapper.RESTMapping(volumeSnapshotClassGK, snapshotv1.SchemeGroupVersion.Version)
+	switch {
+	case err == nil:
+		return true
+	case meta.IsNoMatchError(err):
+		return false
+	default:
+		log.Error(err, "[VolumeSnapshotClassCRDExists] unable to resolve the VolumeSnapshotClass REST mapping")
+		return false
+	}
+}

--- a/module.yaml
+++ b/module.yaml
@@ -7,6 +7,4 @@ descriptions:
   ru: "Предоставляет CSI для управления NFS-томами."
 requirements:
   deckhouse: ">= 1.72"
-  modules:
-    snapshot-controller: ">= 0.0.0"
 namespace: "d8-csi-nfs"

--- a/templates/csi/volume-snapshot-class.yaml
+++ b/templates/csi/volume-snapshot-class.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "snapshot-controller") }}
+{{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshotClass" }}
 ---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass


### PR DESCRIPTION
## Description

Removes the hard `snapshot-controller` dependency and replaces it with a runtime check for the snapshot CRDs.

- `module.yaml`: dropped the `requirements.modules.snapshot-controller` entry (the `requirements.modules` block is now empty and removed).
- `templates/csi/volume-snapshot-class.yaml`: the static `csi-nfs-snapshot-class` is now gated on `.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshotClass"` instead of `.Values.global.enabledModules | has "snapshot-controller"`.
- `images/controller`: added `VolumeSnapshotClassCRDExists`, which resolves the `snapshot.storage.k8s.io` `VolumeSnapshotClass` GroupKind through the RESTMapper. `RunEventReconcile` consults it before listing and reconciling the per-`NFSStorageClass` VolumeSnapshotClass.
- The unit-test fake client now gets an explicit RESTMapper — it defaults to an empty one, which would otherwise read as "the CRD is not installed" and silently skip the existing VolumeSnapshotClass assertions.
- Docs (EN + RU): the README bullet "the snapshot-controller module must be enabled for this module to operate" now scopes the requirement to volume snapshots. The FAQ snapshot walkthrough already framed it correctly and is unchanged.

The RESTMapper the manager builds is dynamic (controller-runtime 0.20), so it reloads discovery on a miss and the CRD is picked up without restarting the controller once a module providing it is enabled.

No changes to critical cluster components; no restarts of ingress-controllers, control-plane or Prometheus.

## Why do we need it, and what problem does it solve?

`snapshot-controller` is no longer the only module shipping the `snapshot.storage.k8s.io` CRDs — `storage-foundation` ships them too, and `snapshot-controller`'s own templates already stand down when `storage-foundation` is enabled. A hard `requirements.modules` entry on `snapshot-controller` therefore blocks `csi-nfs` in clusters where the CRDs are present but come from somewhere else, and forces the module on users who do not need snapshots at all.

Gating on the CRD instead of on the module name makes the dependency describe what the code actually needs.

## What is the expected result?

- With the snapshot CRDs installed (from any module): unchanged behaviour — the static `csi-nfs-snapshot-class` renders and a `VolumeSnapshotClass` is created, updated and deleted for every `NFSStorageClass` exactly as before.
- Without the snapshot CRDs: `csi-nfs` enables and reconciles normally. `NFSStorageClass` objects reach `Created`, the `StorageClass` and mount-options Secret are managed as usual, and the controller logs that the `VolumeSnapshotClass` CRD is not registered instead of erroring. No `VolumeSnapshotClass` is rendered or created.
- Installing a module that provides the CRDs afterwards: the next Helm release renders the static class and the next reconcile creates the per-`NFSStorageClass` one — no controller restart required.
- `csi-nfs` can be enabled in a cluster where `snapshot-controller` is disabled, which Deckhouse previously rejected.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
