### PR TITLE
fix(status): truncate the condition message to what the schema allows

### DIFF
--- a/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/nfs_storage_class_watcher_func.go
@@ -549,6 +549,14 @@ func updateNFSStorageClassPhase(ctx context.Context, cl client.Client, nsc *v1al
 		// message tells `kubectl describe` nothing.
 		cond.Message = fmt.Sprintf("the NFSStorageClass is in the %s phase", phase)
 	}
+	// The schema caps the message at 32768, and the failure paths pass
+	// err.Error() straight through. Over the cap the API server rejects the
+	// whole status write, so the resource keeps reporting its previous verdict
+	// and the reconcile fails on the write rather than on what actually went
+	// wrong. conditions.Set does not truncate: it is a thin wrapper over
+	// meta.SetStatusCondition, and only the library's Ready and
+	// ReadyWithMessage builders truncate for you.
+	cond.Message = conditions.TruncateMessage(cond.Message)
 
 	return conditions.UpdateStatus(ctx, cl, nsc, func(sc *v1alpha1.NFSStorageClass) {
 		if sc.Status == nil {

--- a/images/controller/pkg/controller/status_conditions_test.go
+++ b/images/controller/pkg/controller/status_conditions_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -183,7 +184,11 @@ func TestUpdateNFSStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) {
 	}
 	cl := newStatusTestClient(t, nsc)
 
-	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+	// Multi-byte on purpose. The schema's maxLength is an OpenAPI string
+	// length, counted in runes, and TruncateMessage counts the same way — a
+	// byte-counting assertion here would fail on a message that is in fact
+	// within the limit.
+	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
 	if err := updateNFSStorageClassPhase(context.Background(), cl, nsc, FailedStatusPhase, huge); err != nil {
 		t.Fatalf("updateNFSStorageClassPhase: %v", err)
 	}
@@ -192,9 +197,9 @@ func TestUpdateNFSStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) {
 	if ready == nil {
 		t.Fatal("Ready condition was not published")
 	}
-	if len(ready.Message) > conditions.MaxMessageLen {
-		t.Errorf("message is %d bytes, over the %d the schema allows",
-			len(ready.Message), conditions.MaxMessageLen)
+	if utf8.RuneCountInString(ready.Message) > conditions.MaxMessageLen {
+		t.Errorf("message is %d runes, over the %d the schema allows",
+			utf8.RuneCountInString(ready.Message), conditions.MaxMessageLen)
 	}
 }
 

--- a/images/controller/pkg/controller/status_conditions_test.go
+++ b/images/controller/pkg/controller/status_conditions_test.go
@@ -188,7 +188,10 @@ func TestUpdateNFSStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) {
 	// length, counted in runes, and TruncateMessage counts the same way — a
 	// byte-counting assertion here would fail on a message that is in fact
 	// within the limit.
-	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
+	//
+	// Written as an escape rather than the character itself: the module linter
+	// rejects non-ASCII bytes in Go sources.
+	huge := strings.Repeat("\u044f", conditions.MaxMessageLen+100)
 	if err := updateNFSStorageClassPhase(context.Background(), cl, nsc, FailedStatusPhase, huge); err != nil {
 		t.Fatalf("updateNFSStorageClassPhase: %v", err)
 	}

--- a/images/controller/pkg/controller/status_conditions_test.go
+++ b/images/controller/pkg/controller/status_conditions_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -169,6 +170,31 @@ func TestUpdateNFSStorageClassPhase_Failed(t *testing.T) {
 	}
 	if got.Status.Phase != FailedStatusPhase {
 		t.Errorf("phase = %q, want %q", got.Status.Phase, FailedStatusPhase)
+	}
+}
+
+// The failure paths pass err.Error() through as the condition message, and the
+// schema caps it at 32768. Over the cap the API server rejects the whole status
+// write, so the resource keeps reporting its previous verdict and the reconcile
+// fails on the write instead of on what actually went wrong.
+func TestUpdateNFSStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) {
+	nsc := &v1alpha1.NFSStorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: testNSCName, Generation: 1},
+	}
+	cl := newStatusTestClient(t, nsc)
+
+	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+	if err := updateNFSStorageClassPhase(context.Background(), cl, nsc, FailedStatusPhase, huge); err != nil {
+		t.Fatalf("updateNFSStorageClassPhase: %v", err)
+	}
+
+	ready := conditions.Get(readNSC(t, cl).Status.Conditions, v1alpha1.ConditionTypeReady)
+	if ready == nil {
+		t.Fatal("Ready condition was not published")
+	}
+	if len(ready.Message) > conditions.MaxMessageLen {
+		t.Errorf("message is %d bytes, over the %d the schema allows",
+			len(ready.Message), conditions.MaxMessageLen)
 	}
 }
 


### PR DESCRIPTION
## Description

The controller builds its `Ready` condition by hand and passes `err.Error()` through as the message. The CRD caps `message` at 32768 — the limit `metav1.Condition` itself declares, applied when the conditions schema was tightened. Nothing between the two truncates.

`conditions.Set` looks like it would, but it does not: it is a thin wrapper over `meta.SetStatusCondition`. Only the library's `Ready` and `ReadyWithMessage` builders call `TruncateMessage`, and this module does not use them.

The fix truncates at the single point where a condition reaches the API server, so it covers the existing callers and any added later.

## Why do we need it, and what problem does it solve?

An oversized message does not get trimmed by the API server — the whole status write is rejected. Three things follow, in order of how confusing they are:

1. The resource keeps advertising its **previous** verdict. A `Ready=True` from the last successful pass survives the failure that should have replaced it, so an alert on `Ready=False` never fires for exactly the failure that produced the most output.
2. The reconcile fails on the status write rather than on the underlying problem, so the log names an admission error instead of the thing that actually broke.
3. It is self-reinforcing: the longer the error, the more certain it is to be lost.

The errors that reach this length are the ones worth reading — an aggregate over many nodes, or a command's captured output.

## What is the expected result?

A failure whose message exceeds 32768 is published with the message truncated to the cap (the library appends an ellipsis), `Ready=False` and `reason: ReconcileFailed`, instead of the status write being rejected.

Unchanged: `status.reason`, which the schema does not limit, still carries the full text; the debug logs still print it untruncated; messages under the cap are byte-for-byte what they were.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
